### PR TITLE
WIP: eliminate global cutest_lib

### DIFF
--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -9,12 +9,10 @@ using Compat
 import Compat.String
 import Base.Libdl.dlsym
 
-# Only one problem can be interfaced at any given time.
-global cutest_instances = 0
-
 export CUTEstModel, sifdecoder
 
 type CUTEstModel <: AbstractNLPModel
+  lib     :: Ptr{Void}
   meta    :: NLPModelMeta;
 
   counters :: Counters
@@ -45,7 +43,6 @@ type CUTEstException <: Exception
 end
 
 function __init__()
-  global cutest_lib = C_NULL
   deps = joinpath(dirname(@__FILE__), "../deps")
   cutestenv = joinpath(deps, "cutestenv.jl")
   ispath(cutestenv) && include(cutestenv)
@@ -92,15 +89,12 @@ function sifdecoder(name :: String, args...; verbose :: Bool=false)
   run(`gfortran -c -fPIC ELFUN.f EXTER.f GROUP.f RANGE.f`);
   run(`$linker $sh_flags -o $libname.$(Libdl.dlext) ELFUN.o EXTER.o GROUP.o RANGE.o $libpath`);
   run(`rm ELFUN.f EXTER.f GROUP.f RANGE.f ELFUN.o EXTER.o GROUP.o RANGE.o`);
-  global cutest_lib = Libdl.dlopen(libname,
+  cutest_lib = Libdl.dlopen(libname,
       Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
 end
 
 # Initialize problem.
 function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Bool=false)
-  global cutest_instances
-  cutest_instances > 0 && error("CUTEst: call cutest_finalize on current model first")
-  global cutest_lib
   if !decode
     (isfile(outsdif) && isfile(automat)) || error("CUTEst: no decoded problem found")
     libname = "lib$name"
@@ -108,7 +102,7 @@ function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Boo
     cutest_lib = Libdl.dlopen(libname,
         Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
   else
-    sifdecoder(name, args..., verbose=verbose)
+    cutest_lib = sifdecoder(name, args..., verbose=verbose)
   end
   io_err = Cint[0];
   ccall(dlsym(cutest_lib, :fortran_open_), Void,
@@ -119,7 +113,7 @@ function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Boo
   nvar = Cint[0];
   ncon = Cint[0];
 
-  cdimen(io_err, [funit], nvar, ncon)
+  cdimen(cutest_lib, io_err, [funit], nvar, ncon)
   @cutest_error
   nvar = nvar[1];
   ncon = ncon[1];
@@ -135,10 +129,10 @@ function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Boo
 
   if ncon > 0
     # Equality constraints first, linear constraints first, nonlinear variables first.
-    csetup(io_err, [funit], Cint[0], Cint[6], [nvar], [ncon], x, bl, bu, v, cl, cu,
+    csetup(cutest_lib, io_err, [funit], Cint[0], Cint[6], [nvar], [ncon], x, bl, bu, v, cl, cu,
       equatn, linear, Cint[1], Cint[1], Cint[1])
   else
-    usetup(io_err, [funit], Cint[0], Cint[6], [nvar], x, bl, bu)
+    usetup(cutest_lib, io_err, [funit], Cint[0], Cint[6], [nvar], x, bl, bu)
   end
   @cutest_error
 
@@ -156,11 +150,11 @@ function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Boo
   nnzj = Cint[0];
 
   if ncon > 0
-    cdimsh(io_err, nnzh)
-    cdimsj(io_err, nnzj)
+    cdimsh(cutest_lib, io_err, nnzh)
+    cdimsj(cutest_lib, io_err, nnzj)
     nnzj[1] -= nvar;  # nnzj also counts the nonzeros in the objective gradient.
   else
-    udimsh(io_err, nnzh)
+    udimsh(cutest_lib, io_err, nnzh)
   end
   @cutest_error
 
@@ -178,9 +172,8 @@ function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Boo
                       nlin=nlin, nnln=nnln,
                       name=splitext(name)[1]);
 
-  nlp = CUTEstModel(meta, Counters())
+  nlp = CUTEstModel(cutest_lib, meta, Counters())
 
-  cutest_instances += 1;
   finalizer(nlp, cutest_finalize)
 
   return nlp
@@ -188,19 +181,16 @@ end
 
 
 function cutest_finalize(nlp :: CUTEstModel)
-  global cutest_instances
-  cutest_instances == 0 && return;
-  global cutest_lib
+  nlp.lib == C_NULL && return  # prevent double-finalization
   io_err = Cint[0];
   if nlp.meta.ncon > 0
-    cterminate(io_err)
+    cterminate(nlp.lib, io_err)
   else
-    uterminate(io_err)
+    uterminate(nlp.lib, io_err)
   end
   @cutest_error
-  Libdl.dlclose(cutest_lib)
-  cutest_instances -= 1;
-  cutest_lib = C_NULL
+  Libdl.dlclose(nlp.lib)
+  nlp.lib = C_NULL
   return;
 end
 

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -32,7 +32,7 @@ Usage:
   - x_l:       [OUT] Array{Cdouble, 1}
   - x_u:       [OUT] Array{Cdouble, 1}
 """
-function usetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
+function usetup(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
     io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_usetup_"), Void,
@@ -78,7 +78,7 @@ linear, e_order, l_order, v_order)
   - l_order:   [IN] Array{Cint, 1}
   - v_order:   [IN] Array{Cint, 1}
 """
-function csetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
+function csetup(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
     io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1},
     y::Array{Cdouble, 1}, c_l::Array{Cdouble, 1}, c_u::Array{Cdouble, 1},
@@ -111,7 +111,7 @@ Usage:
   - input:   [IN] Array{Cint, 1}
   - n:       [OUT] Array{Cint, 1}
 """
-function udimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1})
+function udimen(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_udimen_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, input, n)
@@ -137,7 +137,7 @@ Usage:
   - io_err:  [OUT] Array{Cint, 1}
   - nnzh:    [OUT] Array{Cint, 1}
 """
-function udimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
+function udimsh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_udimsh_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzh)
@@ -167,7 +167,7 @@ Usage:
   - he_val_ne: [OUT] Array{Cint, 1}
   - he_row_ne: [OUT] Array{Cint, 1}
 """
-function udimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
+function udimse(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
     he_row_ne::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_udimse_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -194,7 +194,7 @@ Usage:
   - n:       [IN] Array{Cint, 1}
   - x_type:  [OUT] Array{Cint, 1}
 """
-function uvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
+function uvartype(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_uvartype_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x_type)
@@ -219,7 +219,7 @@ Usage:
   - pname:   [OUT] Array{Cchar, 1}
   - vname:   [OUT] Array{Cchar, 1}
 """
-function unames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, pname::Array{Cchar, 1},
+function unames(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, pname::Array{Cchar, 1},
     vname::Array{Cchar, 1})
   ccall(dlsym(cutest_lib, "cutest_unames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}),
@@ -246,7 +246,7 @@ Usage:
   - calls:   [OUT] Array{Cdouble, 1}
   - time:    [OUT] Array{Cdouble, 1}
 """
-function ureport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
+function ureport(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
     1})
   ccall(dlsym(cutest_lib, "cutest_ureport_"), Void,
     (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
@@ -276,7 +276,7 @@ Usage:
   - n:       [OUT] Array{Cint, 1}
   - m:       [OUT] Array{Cint, 1}
 """
-function cdimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
+function cdimen(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
     m::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cdimen_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -306,7 +306,7 @@ Usage:
   - io_err:  [OUT] Array{Cint, 1}
   - nnzj:    [OUT] Array{Cint, 1}
 """
-function cdimsj(io_err::Array{Cint, 1}, nnzj::Array{Cint, 1})
+function cdimsj(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, nnzj::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cdimsj_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzj)
@@ -334,7 +334,7 @@ Usage:
   - io_err:  [OUT] Array{Cint, 1}
   - nnzh:    [OUT] Array{Cint, 1}
 """
-function cdimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
+function cdimsh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cdimsh_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzh)
@@ -362,7 +362,7 @@ Usage:
   - io_err:  [OUT] Array{Cint, 1}
   - nnzchp:  [OUT] Array{Cint, 1}
 """
-function cdimchp(io_err::Array{Cint, 1}, nnzchp::Array{Cint, 1})
+function cdimchp(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, nnzchp::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cdimchp_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzchp)
@@ -394,7 +394,7 @@ Usage:
   - he_val_ne: [OUT] Array{Cint, 1}
   - he_row_ne: [OUT] Array{Cint, 1}
 """
-function cdimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
+function cdimse(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
     he_row_ne::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cdimse_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -412,7 +412,7 @@ linear_constraints)
   - equality_constraints:            [OUT] Array{Cint, 1}
   - linear_constraints:              [OUT] Array{Cint, 1}
 """
-function cstats(io_err::Array{Cint, 1}, nonlinear_variables_objective::Array{Cint, 1},
+function cstats(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, nonlinear_variables_objective::Array{Cint, 1},
     nonlinear_variables_constraints::Array{Cint, 1},
     equality_constraints::Array{Cint, 1}, linear_constraints::Array{Cint,
     1})
@@ -445,7 +445,7 @@ Usage:
   - n:       [IN] Array{Cint, 1}
   - x_type:  [OUT] Array{Cint, 1}
 """
-function cvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
+function cvartype(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cvartype_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x_type)
@@ -475,7 +475,7 @@ Usage:
   - vname:   [OUT] Array{Cchar, 1}
   - cname:   [OUT] Array{Cchar, 1}
 """
-function cnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cnames(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     pname::Array{Cchar, 1}, vname::Array{Cchar, 1}, cname::Array{Cchar, 1})
   ccall(dlsym(cutest_lib, "cutest_cnames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}),
@@ -504,7 +504,7 @@ Usage:
   - calls:   [OUT] Array{Cdouble, 1}
   - time:    [OUT] Array{Cdouble, 1}
 """
-function creport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
+function creport(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
     1})
   ccall(dlsym(cutest_lib, "cutest_creport_"), Void,
     (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
@@ -532,7 +532,7 @@ Usage:
   - m:       [IN] Array{Cint, 1}
   - cname:   [OUT] Array{Cchar, 1}
 """
-function connames(io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{Cchar, 1})
+function connames(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{Cchar, 1})
   ccall(dlsym(cutest_lib, "cutest_connames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
     io_err, m, cname)
@@ -560,7 +560,7 @@ Usage:
   - input:   [IN] Array{Cint, 1}
   - pname:   [OUT] Array{Cchar, 1}
 """
-function pname(io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{Cchar, 1})
+function pname(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{Cchar, 1})
   ccall(dlsym(cutest_lib, "cutest_pname_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
     io_err, input, pname)
@@ -585,7 +585,7 @@ Usage:
   - io_err:  [OUT] Array{Cint, 1}
   - pname:   [OUT] Array{Cchar, 1}
 """
-function probname(io_err::Array{Cint, 1}, pname::Array{Cchar, 1})
+function probname(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, pname::Array{Cchar, 1})
   ccall(dlsym(cutest_lib, "cutest_probname_"), Void,
     (Ptr{Cint}, Ptr{Cchar}),
     io_err, pname)
@@ -612,7 +612,7 @@ Usage:
   - n:       [IN] Array{Cint, 1}
   - vname:   [OUT] Array{Cchar, 1}
 """
-function varnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{Cchar, 1})
+function varnames(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{Cchar, 1})
   ccall(dlsym(cutest_lib, "cutest_varnames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
     io_err, n, vname)
@@ -638,7 +638,7 @@ Usage:
   - x:       [IN] Array{Cdouble, 1}
   - f:       [OUT] Array{Cdouble, 1}
 """
-function ufn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ufn(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     f::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_ufn_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
@@ -665,7 +665,7 @@ Usage:
   - x:       [IN] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
 """
-function ugr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ugr(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     g::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_ugr_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
@@ -695,7 +695,7 @@ Usage:
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function uofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function uofg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_uofg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
@@ -725,7 +725,7 @@ Usage:
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
 """
-function udh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function udh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
   ccall(dlsym(cutest_lib, "cutest_udh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
@@ -755,7 +755,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ushp(io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzh::Array{Cint, 1},
+function ushp(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_ushp_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -788,7 +788,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ush(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ush(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     nnzh::Array{Cint, 1}, lh::Array{Cint, 1}, h_val::Array{Cdouble, 1},
     h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_ush_"), Void,
@@ -829,7 +829,7 @@ lhe_val, he_val, byrows)
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
 """
-function ueh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ueh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint,
     1}, he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
     he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
@@ -865,7 +865,7 @@ Usage:
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
 """
-function ugrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ugrdh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     g::Array{Cdouble, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
   ccall(dlsym(cutest_lib, "cutest_ugrdh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
@@ -900,7 +900,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ugrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ugrsh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     g::Array{Cdouble, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
     h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_ugrsh_"), Void,
@@ -943,7 +943,7 @@ lhe_val, he_val, byrows)
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
 """
-function ugreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ugreh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     g::Array{Cdouble, 1}, ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1},
     he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
     lhe_row::Array{Cint, 1}, he_row::Array{Cint, 1}, lhe_val::Array{Cint,
@@ -979,7 +979,7 @@ Usage:
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
 """
-function uhprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
+function uhprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
     x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
     result::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_uhprod_"), Void,
@@ -1016,7 +1016,7 @@ index_nz_result, result)
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Cdouble, 1}
 """
-function ushprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
+function ushprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
     x::Array{Cdouble, 1}, nnz_vector::Array{Cint, 1},
     index_nz_vector::Array{Cint, 1}, vector::Array{Cdouble, 1},
     nnz_result::Array{Cint, 1}, index_nz_result::Array{Cint, 1},
@@ -1053,7 +1053,7 @@ Usage:
   - lbandh:            [IN] Array{Cint, 1}
   - max_semibandwidth: [OUT] Array{Cint, 1}
 """
-function ubandh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function ubandh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     semibandwidth::Array{Cint, 1}, h_band::Array{Cdouble, 2},
     lbandh::Array{Cint, 1}, max_semibandwidth::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_ubandh_"), Void,
@@ -1087,7 +1087,7 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - c:       [OUT] Array{Cdouble, 1}
 """
-function cfn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cfn(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, f::Array{Cdouble, 1}, c::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_cfn_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
@@ -1120,7 +1120,7 @@ Usage:
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function cofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function cofg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cofg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
@@ -1156,7 +1156,7 @@ Usage:
   - g_var:   [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function cofsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function cofsg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     f::Array{Cdouble, 1}, nnzg::Array{Cint, 1}, lg::Array{Cint, 1},
     g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1}, grad::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cofsg_"), Void,
@@ -1194,7 +1194,7 @@ Usage:
   - cjac:    [OUT] Array{Cdouble, 2}
   - grad:    [IN] Array{Cint, 1}
 """
-function ccfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function ccfg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, jtrans::Array{Cint, 1},
     lcjac1::Array{Cint, 1}, lcjac2::Array{Cint, 1}, cjac::Array{Cdouble,
     2}, grad::Array{Cint, 1})
@@ -1231,7 +1231,7 @@ Usage:
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function clfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function clfg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, f::Array{Cdouble, 1},
     g::Array{Cdouble, 1}, grad::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_clfg_"), Void,
@@ -1271,7 +1271,7 @@ Usage:
   - lj2:     [IN] Array{Cint, 1}
   - j_val:   [OUT] Array{Cdouble, 2}
 """
-function cgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cgr(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
     lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2})
@@ -1314,7 +1314,7 @@ Usage:
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
 """
-function csgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function csgr(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
     j_var::Array{Cint, 1}, j_fun::Array{Cint, 1})
@@ -1355,7 +1355,7 @@ Usage:
   - j_fun:   [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function ccfsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function ccfsg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, nnzj::Array{Cint, 1},
     lj::Array{Cint, 1}, j_val::Array{Cdouble, 1}, j_var::Array{Cint, 1},
     j_fun::Array{Cint, 1}, grad::Array{Cint, 1})
@@ -1392,7 +1392,7 @@ Usage:
   - gci:     [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function ccifg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
+function ccifg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
     x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, gci::Array{Cdouble, 1},
     grad::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_ccifg_"), Void,
@@ -1432,7 +1432,7 @@ Usage:
   - gci_var: [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
 """
-function ccifsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
+function ccifsg(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
     x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, nnzgci::Array{Cint, 1},
     lgci::Array{Cint, 1}, gci_val::Array{Cdouble, 1}, gci_var::Array{Cint,
     1}, grad::Array{Cint, 1})
@@ -1477,7 +1477,7 @@ Usage:
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
 """
-function cgrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cgrdh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
     lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, lh1::Array{Cint, 1},
@@ -1516,7 +1516,7 @@ Usage:
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
 """
-function cdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cdh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
     h_val::Array{Cdouble, 2})
   ccall(dlsym(cutest_lib, "cutest_cdh_"), Void,
@@ -1552,7 +1552,7 @@ Usage:
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
 """
-function cdhc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cdhc(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
     h_val::Array{Cdouble, 2})
   ccall(dlsym(cutest_lib, "cutest_cdhc_"), Void,
@@ -1586,7 +1586,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cshp(io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzh::Array{Cint, 1},
+function cshp(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cshp_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -1623,7 +1623,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function csh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function csh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
     h_col::Array{Cint, 1})
@@ -1663,7 +1663,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cshc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cshc(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
     h_col::Array{Cint, 1})
@@ -1710,7 +1710,7 @@ he_row, lhe_val, he_val, byrows)
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
 """
-function ceh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function ceh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, ne::Array{Cint, 1},
     lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
     he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
@@ -1750,7 +1750,7 @@ Usage:
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
 """
-function cidh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function cidh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     iprob::Array{Cint, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
   ccall(dlsym(cutest_lib, "cutest_cidh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
@@ -1786,7 +1786,7 @@ Usage:
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cish(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+function cish(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     iprob::Array{Cint, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
     h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cish_"), Void,
@@ -1834,7 +1834,7 @@ h_val, h_row, h_col)
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function csgrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function csgrsh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
     j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, nnzh::Array{Cint, 1},
@@ -1895,7 +1895,7 @@ byrows)
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
 """
-function csgreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function csgreh(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
     j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, ne::Array{Cint, 1},
@@ -1941,7 +1941,7 @@ Usage:
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
 """
-function chprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function chprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
     vector::Array{Cdouble, 1}, result::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_chprod_"), Void,
@@ -1983,7 +1983,7 @@ nnz_result, index_nz_result, result)
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Cdouble, 1}
 """
-function cshprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cshprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
     nnz_vector::Array{Cint, 1}, index_nz_vector::Array{Cint, 1},
     vector::Array{Cdouble, 1}, nnz_result::Array{Cint, 1},
@@ -2024,7 +2024,7 @@ Usage:
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
 """
-function chcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function chcprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
     vector::Array{Cdouble, 1}, result::Array{Cdouble, 1})
   ccall(dlsym(cutest_lib, "cutest_chcprod_"), Void,
@@ -2066,7 +2066,7 @@ nnz_result, index_nz_result, result)
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Cdouble, 1}
 """
-function cshcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cshcprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
     nnz_vector::Array{Cint, 1}, index_nz_vector::Array{Cint, 1},
     vector::Array{Cdouble, 1}, nnz_result::Array{Cint, 1},
@@ -2109,7 +2109,7 @@ Usage:
   - result:  [OUT] Array{Cdouble, 1}
   - lresult: [IN] Array{Cint, 1}
 """
-function cjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cjprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
     vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
     result::Array{Cdouble, 1}, lresult::Array{Cint, 1})
@@ -2154,7 +2154,7 @@ lvector, nnz_result, index_nz_result, result, lresult)
   - result:          [OUT] Array{Cdouble, 1}
   - lresult:         [IN] Array{Cint, 1}
 """
-function csjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function csjprod(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
     nnz_vector::Array{Cint, 1}, index_nz_vector::Array{Cint, 1},
     vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
@@ -2198,7 +2198,7 @@ Usage:
   - chp_ind: [IN] Array{Cint, 1}
   - chp_ptr: [IN] Array{Cint, 1}
 """
-function cchprods(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+function cchprods(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
     lchp::Array{Cint, 1}, chp_val::Array{Cdouble, 1}, chp_ind::Array{Cint,
     1}, chp_ptr::Array{Cint, 1})
@@ -2222,7 +2222,7 @@ Usage:
 
   - io_err:  [OUT] Array{Cint, 1}
 """
-function uterminate(io_err::Array{Cint, 1})
+function uterminate(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_uterminate_"), Void,
     (Ptr{Cint},),
     io_err)
@@ -2242,9 +2242,8 @@ Usage:
 
   - io_err:  [OUT] Array{Cint, 1}
 """
-function cterminate(io_err::Array{Cint, 1})
+function cterminate(cutest_lib::Ptr{Void}, io_err::Array{Cint, 1})
   ccall(dlsym(cutest_lib, "cutest_cterminate_"), Void,
     (Ptr{Cint},),
     io_err)
 end
-

--- a/src/specialized_interface.jl
+++ b/src/specialized_interface.jl
@@ -27,12 +27,12 @@ export usetup!, csetup!, udimen!, udimsh!, udimse!, uvartype!,
   - x_l:       [OUT] Array{Float64, 1}
   - x_u:       [OUT] Array{Float64, 1}
 """
-function usetup(input::Int, out::Int, io_buffer::Int, n::Int)
+function usetup(cutest_lib::Ptr{Void}, input::Int, out::Int, io_buffer::Int, n::Int)
   io_err = Cint[0]
   x = Array(Cdouble, n)
   x_l = Array(Cdouble, n)
   x_u = Array(Cdouble, n)
-  usetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n], x,
+  usetup(cutest_lib, io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n], x,
     x_l, x_u)
   @cutest_error
   return x, x_l, x_u
@@ -49,10 +49,10 @@ end
   - x_l:       [OUT] Array{Float64, 1}
   - x_u:       [OUT] Array{Float64, 1}
 """
-function usetup!(input::Int, out::Int, io_buffer::Int, n::Int, x::Array{Float64, 1},
+function usetup!(cutest_lib::Ptr{Void}, input::Int, out::Int, io_buffer::Int, n::Int, x::Array{Float64, 1},
     x_l::Array{Float64, 1}, x_u::Array{Float64, 1})
   io_err = Cint[0]
-  usetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n], x,
+  usetup(cutest_lib, io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n], x,
     x_l, x_u)
   @cutest_error
   return
@@ -78,7 +78,7 @@ end
   - l_order:   [IN] Int
   - v_order:   [IN] Int
 """
-function csetup(input::Int, out::Int, io_buffer::Int, n::Int, m::Int, e_order::Int,
+function csetup(cutest_lib::Ptr{Void}, input::Int, out::Int, io_buffer::Int, n::Int, m::Int, e_order::Int,
     l_order::Int, v_order::Int)
   io_err = Cint[0]
   x = Array(Cdouble, n)
@@ -89,7 +89,7 @@ function csetup(input::Int, out::Int, io_buffer::Int, n::Int, m::Int, e_order::I
   c_u = Array(Cdouble, m)
   equatn = Array(Cint, m)
   linear = Array(Cint, m)
-  csetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n],
+  csetup(cutest_lib, io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n],
     Cint[m], x, x_l, x_u, y, c_l, c_u, equatn, linear, Cint[e_order],
     Cint[l_order], Cint[v_order])
   @cutest_error
@@ -116,13 +116,13 @@ end
   - l_order:   [IN] Int
   - v_order:   [IN] Int
 """
-function csetup!(input::Int, out::Int, io_buffer::Int, n::Int, m::Int,
+function csetup!(cutest_lib::Ptr{Void}, input::Int, out::Int, io_buffer::Int, n::Int, m::Int,
     x::Array{Float64, 1}, x_l::Array{Float64, 1}, x_u::Array{Float64, 1},
     y::Array{Float64, 1}, c_l::Array{Float64, 1}, c_u::Array{Float64, 1},
     equatn::Array{Cint, 1}, linear::Array{Cint, 1}, e_order::Int,
     l_order::Int, v_order::Int)
   io_err = Cint[0]
-  csetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n],
+  csetup(cutest_lib, io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n],
     Cint[m], x, x_l, x_u, y, c_l, c_u, equatn, linear, Cint[e_order],
     Cint[l_order], Cint[v_order])
   @cutest_error
@@ -135,10 +135,10 @@ end
   - input:   [IN] Int
   - n:       [OUT] Int
 """
-function udimen(input::Int)
+function udimen(cutest_lib::Ptr{Void}, input::Int)
   io_err = Cint[0]
   n = Cint[0]
-  udimen(io_err, Cint[input], n)
+  udimen(cutest_lib, io_err, Cint[input], n)
   @cutest_error
   return n[1]
 end
@@ -148,10 +148,10 @@ end
 
   - nnzh:    [OUT] Int
 """
-function udimsh()
+function udimsh(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   nnzh = Cint[0]
-  udimsh(io_err, nnzh)
+  udimsh(cutest_lib, io_err, nnzh)
   @cutest_error
   return nnzh[1]
 end
@@ -163,12 +163,12 @@ end
   - he_val_ne: [OUT] Int
   - he_row_ne: [OUT] Int
 """
-function udimse()
+function udimse(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   ne = Cint[0]
   he_val_ne = Cint[0]
   he_row_ne = Cint[0]
-  udimse(io_err, ne, he_val_ne, he_row_ne)
+  udimse(cutest_lib, io_err, ne, he_val_ne, he_row_ne)
   @cutest_error
   return ne[1], he_val_ne[1], he_row_ne[1]
 end
@@ -179,10 +179,10 @@ end
   - n:       [IN] Int
   - x_type:  [OUT] Array{Cint, 1}
 """
-function uvartype(n::Int)
+function uvartype(cutest_lib::Ptr{Void}, n::Int)
   io_err = Cint[0]
   x_type = Array(Cint, n)
-  uvartype(io_err, Cint[n], x_type)
+  uvartype(cutest_lib, io_err, Cint[n], x_type)
   @cutest_error
   return x_type
 end
@@ -193,9 +193,9 @@ end
   - n:       [IN] Int
   - x_type:  [OUT] Array{Cint, 1}
 """
-function uvartype!(n::Int, x_type::Array{Cint, 1})
+function uvartype!(cutest_lib::Ptr{Void}, n::Int, x_type::Array{Cint, 1})
   io_err = Cint[0]
-  uvartype(io_err, Cint[n], x_type)
+  uvartype(cutest_lib, io_err, Cint[n], x_type)
   @cutest_error
   return
 end
@@ -207,11 +207,11 @@ end
   - pname:   [OUT] UInt8
   - vname:   [OUT] Array{UInt8, 1}
 """
-function unames(n::Int)
+function unames(cutest_lib::Ptr{Void}, n::Int)
   io_err = Cint[0]
   pname = Cchar[0]
   vname = Array(Cchar, n)
-  unames(io_err, Cint[n], pname, vname)
+  unames(cutest_lib, io_err, Cint[n], pname, vname)
   @cutest_error
   return pname[1], vname
 end
@@ -223,10 +223,10 @@ end
   - pname:   [OUT] UInt8
   - vname:   [OUT] Array{UInt8, 1}
 """
-function unames!(n::Int, vname::Array{UInt8, 1})
+function unames!(cutest_lib::Ptr{Void}, n::Int, vname::Array{UInt8, 1})
   io_err = Cint[0]
   pname = Cchar[0]
-  unames(io_err, Cint[n], pname, vname)
+  unames(cutest_lib, io_err, Cint[n], pname, vname)
   @cutest_error
   return pname[1]
 end
@@ -237,11 +237,11 @@ end
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
 """
-function ureport()
+function ureport(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   calls = Array(Cdouble, 4)
   time = Array(Cdouble, 2)
-  ureport(io_err, calls, time)
+  ureport(cutest_lib, io_err, calls, time)
   @cutest_error
   return calls, time
 end
@@ -252,9 +252,9 @@ end
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
 """
-function ureport!(calls::Array{Float64, 1}, time::Array{Float64, 1})
+function ureport!(cutest_lib::Ptr{Void}, calls::Array{Float64, 1}, time::Array{Float64, 1})
   io_err = Cint[0]
-  ureport(io_err, calls, time)
+  ureport(cutest_lib, io_err, calls, time)
   @cutest_error
   return
 end
@@ -266,11 +266,11 @@ end
   - n:       [OUT] Int
   - m:       [OUT] Int
 """
-function cdimen(input::Int)
+function cdimen(cutest_lib::Ptr{Void}, input::Int)
   io_err = Cint[0]
   n = Cint[0]
   m = Cint[0]
-  cdimen(io_err, Cint[input], n, m)
+  cdimen(cutest_lib, io_err, Cint[input], n, m)
   @cutest_error
   return n[1], m[1]
 end
@@ -280,10 +280,10 @@ end
 
   - nnzj:    [OUT] Int
 """
-function cdimsj()
+function cdimsj(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   nnzj = Cint[0]
-  cdimsj(io_err, nnzj)
+  cdimsj(cutest_lib, io_err, nnzj)
   @cutest_error
   return nnzj[1]
 end
@@ -293,10 +293,10 @@ end
 
   - nnzh:    [OUT] Int
 """
-function cdimsh()
+function cdimsh(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   nnzh = Cint[0]
-  cdimsh(io_err, nnzh)
+  cdimsh(cutest_lib, io_err, nnzh)
   @cutest_error
   return nnzh[1]
 end
@@ -306,10 +306,10 @@ end
 
   - nnzchp:  [OUT] Int
 """
-function cdimchp()
+function cdimchp(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   nnzchp = Cint[0]
-  cdimchp(io_err, nnzchp)
+  cdimchp(cutest_lib, io_err, nnzchp)
   @cutest_error
   return nnzchp[1]
 end
@@ -321,25 +321,25 @@ end
   - he_val_ne: [OUT] Int
   - he_row_ne: [OUT] Int
 """
-function cdimse()
+function cdimse(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   ne = Cint[0]
   he_val_ne = Cint[0]
   he_row_ne = Cint[0]
-  cdimse(io_err, ne, he_val_ne, he_row_ne)
+  cdimse(cutest_lib, io_err, ne, he_val_ne, he_row_ne)
   @cutest_error
   return ne[1], he_val_ne[1], he_row_ne[1]
 end
 
 """
 """
-function cstats()
+function cstats(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   nonlinear_variables_objective = Cint[0]
   nonlinear_variables_constraints = Cint[0]
   equality_constraints = Cint[0]
   linear_constraints = Cint[0]
-  cstats(io_err, nonlinear_variables_objective,
+  cstats(cutest_lib, io_err, nonlinear_variables_objective,
     nonlinear_variables_constraints, equality_constraints,
     linear_constraints)
   @cutest_error
@@ -352,10 +352,10 @@ end
   - n:       [IN] Int
   - x_type:  [OUT] Array{Cint, 1}
 """
-function cvartype(n::Int)
+function cvartype(cutest_lib::Ptr{Void}, n::Int)
   io_err = Cint[0]
   x_type = Array(Cint, n)
-  cvartype(io_err, Cint[n], x_type)
+  cvartype(cutest_lib, io_err, Cint[n], x_type)
   @cutest_error
   return x_type
 end
@@ -366,9 +366,9 @@ end
   - n:       [IN] Int
   - x_type:  [OUT] Array{Cint, 1}
 """
-function cvartype!(n::Int, x_type::Array{Cint, 1})
+function cvartype!(cutest_lib::Ptr{Void}, n::Int, x_type::Array{Cint, 1})
   io_err = Cint[0]
-  cvartype(io_err, Cint[n], x_type)
+  cvartype(cutest_lib, io_err, Cint[n], x_type)
   @cutest_error
   return
 end
@@ -382,12 +382,12 @@ end
   - vname:   [OUT] Array{UInt8, 1}
   - cname:   [OUT] Array{UInt8, 1}
 """
-function cnames(n::Int, m::Int)
+function cnames(cutest_lib::Ptr{Void}, n::Int, m::Int)
   io_err = Cint[0]
   pname = Cchar[0]
   vname = Array(Cchar, n)
   cname = Array(Cchar, m)
-  cnames(io_err, Cint[n], Cint[m], pname, vname, cname)
+  cnames(cutest_lib, io_err, Cint[n], Cint[m], pname, vname, cname)
   @cutest_error
   return pname[1], vname, cname
 end
@@ -401,10 +401,10 @@ end
   - vname:   [OUT] Array{UInt8, 1}
   - cname:   [OUT] Array{UInt8, 1}
 """
-function cnames!(n::Int, m::Int, vname::Array{UInt8, 1}, cname::Array{UInt8, 1})
+function cnames!(cutest_lib::Ptr{Void}, n::Int, m::Int, vname::Array{UInt8, 1}, cname::Array{UInt8, 1})
   io_err = Cint[0]
   pname = Cchar[0]
-  cnames(io_err, Cint[n], Cint[m], pname, vname, cname)
+  cnames(cutest_lib, io_err, Cint[n], Cint[m], pname, vname, cname)
   @cutest_error
   return pname[1]
 end
@@ -415,11 +415,11 @@ end
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
 """
-function creport()
+function creport(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   calls = Array(Cdouble, 7)
   time = Array(Cdouble, 2)
-  creport(io_err, calls, time)
+  creport(cutest_lib, io_err, calls, time)
   @cutest_error
   return calls, time
 end
@@ -430,9 +430,9 @@ end
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
 """
-function creport!(calls::Array{Float64, 1}, time::Array{Float64, 1})
+function creport!(cutest_lib::Ptr{Void}, calls::Array{Float64, 1}, time::Array{Float64, 1})
   io_err = Cint[0]
-  creport(io_err, calls, time)
+  creport(cutest_lib, io_err, calls, time)
   @cutest_error
   return
 end
@@ -443,10 +443,10 @@ end
   - m:       [IN] Int
   - cname:   [OUT] Array{UInt8, 1}
 """
-function connames(m::Int)
+function connames(cutest_lib::Ptr{Void}, m::Int)
   io_err = Cint[0]
   cname = Array(Cchar, m)
-  connames(io_err, Cint[m], cname)
+  connames(cutest_lib, io_err, Cint[m], cname)
   @cutest_error
   return cname
 end
@@ -457,9 +457,9 @@ end
   - m:       [IN] Int
   - cname:   [OUT] Array{UInt8, 1}
 """
-function connames!(m::Int, cname::Array{UInt8, 1})
+function connames!(cutest_lib::Ptr{Void}, m::Int, cname::Array{UInt8, 1})
   io_err = Cint[0]
-  connames(io_err, Cint[m], cname)
+  connames(cutest_lib, io_err, Cint[m], cname)
   @cutest_error
   return
 end
@@ -470,10 +470,10 @@ end
   - input:   [IN] Int
   - pname:   [OUT] UInt8
 """
-function pname(input::Int)
+function pname(cutest_lib::Ptr{Void}, input::Int)
   io_err = Cint[0]
   pname = Cchar[0]
-  pname(io_err, Cint[input], pname)
+  pname(cutest_lib, io_err, Cint[input], pname)
   @cutest_error
   return pname[1]
 end
@@ -483,10 +483,10 @@ end
 
   - pname:   [OUT] UInt8
 """
-function probname()
+function probname(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
   pname = Cchar[0]
-  probname(io_err, pname)
+  probname(cutest_lib, io_err, pname)
   @cutest_error
   return pname[1]
 end
@@ -497,10 +497,10 @@ end
   - n:       [IN] Int
   - vname:   [OUT] Array{UInt8, 1}
 """
-function varnames(n::Int)
+function varnames(cutest_lib::Ptr{Void}, n::Int)
   io_err = Cint[0]
   vname = Array(Cchar, n)
-  varnames(io_err, Cint[n], vname)
+  varnames(cutest_lib, io_err, Cint[n], vname)
   @cutest_error
   return vname
 end
@@ -511,9 +511,9 @@ end
   - n:       [IN] Int
   - vname:   [OUT] Array{UInt8, 1}
 """
-function varnames!(n::Int, vname::Array{UInt8, 1})
+function varnames!(cutest_lib::Ptr{Void}, n::Int, vname::Array{UInt8, 1})
   io_err = Cint[0]
-  varnames(io_err, Cint[n], vname)
+  varnames(cutest_lib, io_err, Cint[n], vname)
   @cutest_error
   return
 end
@@ -525,10 +525,10 @@ end
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
 """
-function ufn(n::Int, x::Array{Float64, 1})
+function ufn(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1})
   io_err = Cint[0]
   f = Cdouble[0]
-  ufn(io_err, Cint[n], x, f)
+  ufn(cutest_lib, io_err, Cint[n], x, f)
   @cutest_error
   return f[1]
 end
@@ -540,10 +540,10 @@ end
   - x:       [IN] Array{Float64, 1}
   - g:       [OUT] Array{Float64, 1}
 """
-function ugr(n::Int, x::Array{Float64, 1})
+function ugr(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1})
   io_err = Cint[0]
   g = Array(Cdouble, n)
-  ugr(io_err, Cint[n], x, g)
+  ugr(cutest_lib, io_err, Cint[n], x, g)
   @cutest_error
   return g
 end
@@ -555,9 +555,9 @@ end
   - x:       [IN] Array{Float64, 1}
   - g:       [OUT] Array{Float64, 1}
 """
-function ugr!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1})
+function ugr!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, g::Array{Float64, 1})
   io_err = Cint[0]
-  ugr(io_err, Cint[n], x, g)
+  ugr(cutest_lib, io_err, Cint[n], x, g)
   @cutest_error
   return
 end
@@ -571,11 +571,11 @@ end
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function uofg(n::Int, x::Array{Float64, 1}, grad::Bool)
+function uofg(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  uofg(io_err, Cint[n], x, f, g, Cint[grad])
+  uofg(cutest_lib, io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
@@ -589,10 +589,10 @@ end
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function uofg!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool)
+function uofg!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
-  uofg(io_err, Cint[n], x, f, g, Cint[grad])
+  uofg(cutest_lib, io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
@@ -605,10 +605,10 @@ end
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
 """
-function udh(n::Int, x::Array{Float64, 1}, lh1::Int)
+function udh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   h = Array(Cdouble, lh1, n)
-  udh(io_err, Cint[n], x, Cint[lh1], h)
+  udh(cutest_lib, io_err, Cint[n], x, Cint[lh1], h)
   @cutest_error
   return h
 end
@@ -621,9 +621,9 @@ end
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
 """
-function udh!(n::Int, x::Array{Float64, 1}, lh1::Int, h::Array{Float64, 2})
+function udh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lh1::Int, h::Array{Float64, 2})
   io_err = Cint[0]
-  udh(io_err, Cint[n], x, Cint[lh1], h)
+  udh(cutest_lib, io_err, Cint[n], x, Cint[lh1], h)
   @cutest_error
   return
 end
@@ -637,12 +637,12 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ushp(n::Int, lh::Int)
+function ushp(cutest_lib::Ptr{Void}, n::Int, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ushp(io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
+  ushp(cutest_lib, io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
   @cutest_error
   return nnzh[1], h_row, h_col
 end
@@ -656,10 +656,10 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ushp!(n::Int, lh::Int, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
+function ushp!(cutest_lib::Ptr{Void}, n::Int, lh::Int, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  ushp(io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
+  ushp(cutest_lib, io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -675,13 +675,13 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ush(n::Int, x::Array{Float64, 1}, lh::Int)
+function ush(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
+  ush(cutest_lib, io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
@@ -697,11 +697,11 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ush!(n::Int, x::Array{Float64, 1}, lh::Int, h_val::Array{Float64, 1},
+function ush!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lh::Int, h_val::Array{Float64, 1},
     h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
+  ush(cutest_lib, io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -721,7 +721,7 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function ueh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
+function ueh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
     lhe_val::Int, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
@@ -729,7 +729,7 @@ function ueh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
   he_val_ptr = Array(Cint, lhe_ptr)
   he_row = Array(Cint, lhe_row)
   he_val = Array(Cdouble, lhe_val)
-  ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
+  ueh(cutest_lib, io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
     Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return ne[1], he_row_ptr, he_val_ptr, he_row, he_val
@@ -750,12 +750,12 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function ueh!(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, he_row_ptr::Array{Cint,
+function ueh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lhe_ptr::Int, he_row_ptr::Array{Cint,
     1}, he_val_ptr::Array{Cint, 1}, lhe_row::Int, he_row::Array{Cint, 1},
     lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
-  ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
+  ueh(cutest_lib, io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
     Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return ne[1]
@@ -770,11 +770,11 @@ end
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
 """
-function ugrdh(n::Int, x::Array{Float64, 1}, lh1::Int)
+function ugrdh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   h = Array(Cdouble, lh1, n)
-  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h)
+  ugrdh(cutest_lib, io_err, Cint[n], x, g, Cint[lh1], h)
   @cutest_error
   return g, h
 end
@@ -788,10 +788,10 @@ end
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
 """
-function ugrdh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh1::Int,
+function ugrdh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh1::Int,
     h::Array{Float64, 2})
   io_err = Cint[0]
-  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h)
+  ugrdh(cutest_lib, io_err, Cint[n], x, g, Cint[lh1], h)
   @cutest_error
   return
 end
@@ -808,14 +808,14 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ugrsh(n::Int, x::Array{Float64, 1}, lh::Int)
+function ugrsh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
+  ugrsh(cutest_lib, io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return g, nnzh[1], h_val, h_row, h_col
 end
@@ -832,12 +832,12 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function ugrsh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh::Int,
+function ugrsh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
     1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
+  ugrsh(cutest_lib, io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -858,7 +858,7 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function ugreh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
+function ugreh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
     lhe_val::Int, byrows::Bool)
   io_err = Cint[0]
   g = Array(Cdouble, n)
@@ -867,7 +867,7 @@ function ugreh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
   he_val_ptr = Array(Cint, lhe_ptr)
   he_row = Array(Cint, lhe_row)
   he_val = Array(Cdouble, lhe_val)
-  ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
+  ugreh(cutest_lib, io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
     Cint[byrows])
   @cutest_error
@@ -890,13 +890,13 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function ugreh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lhe_ptr::Int,
+function ugreh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lhe_ptr::Int,
     he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1}, lhe_row::Int,
     he_row::Array{Cint, 1}, lhe_val::Int, he_val::Array{Float64, 1},
     byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
-  ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
+  ugreh(cutest_lib, io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
     Cint[byrows])
   @cutest_error
@@ -912,10 +912,10 @@ end
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
 """
-function uhprod(n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1})
+function uhprod(cutest_lib::Ptr{Void}, n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   result = Array(Cdouble, n)
-  uhprod(io_err, Cint[n], Cint[goth], x, vector, result)
+  uhprod(cutest_lib, io_err, Cint[n], Cint[goth], x, vector, result)
   @cutest_error
   return result
 end
@@ -929,10 +929,10 @@ end
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
 """
-function uhprod!(n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1},
+function uhprod!(cutest_lib::Ptr{Void}, n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1},
     result::Array{Float64, 1})
   io_err = Cint[0]
-  uhprod(io_err, Cint[n], Cint[goth], x, vector, result)
+  uhprod(cutest_lib, io_err, Cint[n], Cint[goth], x, vector, result)
   @cutest_error
   return
 end
@@ -950,13 +950,13 @@ end
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Float64, 1}
 """
-function ushprod(n::Int, goth::Bool, x::Array{Float64, 1}, nnz_vector::Int,
+function ushprod(cutest_lib::Ptr{Void}, n::Int, goth::Bool, x::Array{Float64, 1}, nnz_vector::Int,
     index_nz_vector::Array{Cint, 1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   nnz_result = Cint[0]
   index_nz_result = Array(Cint, n)
   result = Array(Cdouble, n)
-  ushprod(io_err, Cint[n], Cint[goth], x, Cint[nnz_vector],
+  ushprod(cutest_lib, io_err, Cint[n], Cint[goth], x, Cint[nnz_vector],
     index_nz_vector, vector, nnz_result, index_nz_result, result)
   @cutest_error
   return nnz_result[1], index_nz_result, result
@@ -975,12 +975,12 @@ end
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Float64, 1}
 """
-function ushprod!(n::Int, goth::Bool, x::Array{Float64, 1}, nnz_vector::Int,
+function ushprod!(cutest_lib::Ptr{Void}, n::Int, goth::Bool, x::Array{Float64, 1}, nnz_vector::Int,
     index_nz_vector::Array{Cint, 1}, vector::Array{Float64, 1},
     index_nz_result::Array{Cint, 1}, result::Array{Float64, 1})
   io_err = Cint[0]
   nnz_result = Cint[0]
-  ushprod(io_err, Cint[n], Cint[goth], x, Cint[nnz_vector],
+  ushprod(cutest_lib, io_err, Cint[n], Cint[goth], x, Cint[nnz_vector],
     index_nz_vector, vector, nnz_result, index_nz_result, result)
   @cutest_error
   return nnz_result[1]
@@ -996,11 +996,11 @@ end
   - lbandh:            [IN] Int
   - max_semibandwidth: [OUT] Int
 """
-function ubandh(n::Int, x::Array{Float64, 1}, semibandwidth::Int, lbandh::Int)
+function ubandh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, semibandwidth::Int, lbandh::Int)
   io_err = Cint[0]
   h_band = Array(Cdouble, lbandh - 0 + 1, n)
   max_semibandwidth = Cint[0]
-  ubandh(io_err, Cint[n], x, Cint[semibandwidth], h_band,
+  ubandh(cutest_lib, io_err, Cint[n], x, Cint[semibandwidth], h_band,
     Cint[lbandh], max_semibandwidth)
   @cutest_error
   return h_band, max_semibandwidth[1]
@@ -1016,11 +1016,11 @@ end
   - lbandh:            [IN] Int
   - max_semibandwidth: [OUT] Int
 """
-function ubandh!(n::Int, x::Array{Float64, 1}, semibandwidth::Int,
+function ubandh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, semibandwidth::Int,
     h_band::Array{Float64, 2}, lbandh::Int)
   io_err = Cint[0]
   max_semibandwidth = Cint[0]
-  ubandh(io_err, Cint[n], x, Cint[semibandwidth], h_band,
+  ubandh(cutest_lib, io_err, Cint[n], x, Cint[semibandwidth], h_band,
     Cint[lbandh], max_semibandwidth)
   @cutest_error
   return max_semibandwidth[1]
@@ -1035,11 +1035,11 @@ end
   - f:       [OUT] Float64
   - c:       [OUT] Array{Float64, 1}
 """
-function cfn(n::Int, m::Int, x::Array{Float64, 1})
+function cfn(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1})
   io_err = Cint[0]
   f = Cdouble[0]
   c = Array(Cdouble, m)
-  cfn(io_err, Cint[n], Cint[m], x, f, c)
+  cfn(cutest_lib, io_err, Cint[n], Cint[m], x, f, c)
   @cutest_error
   return f[1], c
 end
@@ -1053,10 +1053,10 @@ end
   - f:       [OUT] Float64
   - c:       [OUT] Array{Float64, 1}
 """
-function cfn!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1})
+function cfn!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1})
   io_err = Cint[0]
   f = Cdouble[0]
-  cfn(io_err, Cint[n], Cint[m], x, f, c)
+  cfn(cutest_lib, io_err, Cint[n], Cint[m], x, f, c)
   @cutest_error
   return f[1]
 end
@@ -1070,11 +1070,11 @@ end
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function cofg(n::Int, x::Array{Float64, 1}, grad::Bool)
+function cofg(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  cofg(io_err, Cint[n], x, f, g, Cint[grad])
+  cofg(cutest_lib, io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
@@ -1088,10 +1088,10 @@ end
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function cofg!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool)
+function cofg!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
-  cofg(io_err, Cint[n], x, f, g, Cint[grad])
+  cofg(cutest_lib, io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
@@ -1108,13 +1108,13 @@ end
   - g_var:   [OUT] Array{Cint, 1}
   - grad:    [IN] Bool
 """
-function cofsg(n::Int, x::Array{Float64, 1}, lg::Int, grad::Bool)
+function cofsg(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lg::Int, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   nnzg = Cint[0]
   g_val = Array(Cdouble, lg)
   g_var = Array(Cint, lg)
-  cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
+  cofsg(cutest_lib, io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
     Cint[grad])
   @cutest_error
   return f[1], nnzg[1], g_val, g_var
@@ -1132,12 +1132,12 @@ end
   - g_var:   [OUT] Array{Cint, 1}
   - grad:    [IN] Bool
 """
-function cofsg!(n::Int, x::Array{Float64, 1}, lg::Int, g_val::Array{Float64, 1},
+function cofsg!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, lg::Int, g_val::Array{Float64, 1},
     g_var::Array{Cint, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   nnzg = Cint[0]
-  cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
+  cofsg(cutest_lib, io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
     Cint[grad])
   @cutest_error
   return f[1], nnzg[1]
@@ -1156,12 +1156,12 @@ end
   - cjac:    [OUT] Array{Float64, 2}
   - grad:    [IN] Bool
 """
-function ccfg(n::Int, m::Int, x::Array{Float64, 1}, jtrans::Bool, lcjac1::Int,
+function ccfg(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, jtrans::Bool, lcjac1::Int,
     lcjac2::Int, grad::Bool)
   io_err = Cint[0]
   c = Array(Cdouble, m)
   cjac = Array(Cdouble, lcjac1, lcjac2)
-  ccfg(io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
+  ccfg(cutest_lib, io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
     Cint[lcjac2], cjac, Cint[grad])
   @cutest_error
   return c, cjac
@@ -1180,11 +1180,11 @@ end
   - cjac:    [OUT] Array{Float64, 2}
   - grad:    [IN] Bool
 """
-function ccfg!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1},
+function ccfg!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1},
     jtrans::Bool, lcjac1::Int, lcjac2::Int, cjac::Array{Float64, 2},
     grad::Bool)
   io_err = Cint[0]
-  ccfg(io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
+  ccfg(cutest_lib, io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
     Cint[lcjac2], cjac, Cint[grad])
   @cutest_error
   return
@@ -1201,12 +1201,12 @@ end
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function clfg(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function clfg(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
+  clfg(cutest_lib, io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
@@ -1222,11 +1222,11 @@ end
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function clfg!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function clfg!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     g::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
-  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
+  clfg(cutest_lib, io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
@@ -1245,12 +1245,12 @@ end
   - lj2:     [IN] Int
   - j_val:   [OUT] Array{Float64, 2}
 """
-function cgr(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function cgr(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, jtrans::Bool, lj1::Int, lj2::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   j_val = Array(Cdouble, lj1, lj2)
-  cgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
+  cgr(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
     Cint[lj1], Cint[lj2], j_val)
   @cutest_error
   return g, j_val
@@ -1270,11 +1270,11 @@ end
   - lj2:     [IN] Int
   - j_val:   [OUT] Array{Float64, 2}
 """
-function cgr!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function cgr!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, g::Array{Float64, 1}, jtrans::Bool, lj1::Int, lj2::Int,
     j_val::Array{Float64, 2})
   io_err = Cint[0]
-  cgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
+  cgr(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
     Cint[lj1], Cint[lj2], j_val)
   @cutest_error
   return
@@ -1294,14 +1294,14 @@ end
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
 """
-function csgr(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function csgr(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int)
   io_err = Cint[0]
   nnzj = Cint[0]
   j_val = Array(Cdouble, lj)
   j_var = Array(Cint, lj)
   j_fun = Array(Cint, lj)
-  csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
+  csgr(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun)
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun
@@ -1321,12 +1321,12 @@ end
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
 """
-function csgr!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function csgr!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Cint,
     1}, j_fun::Array{Cint, 1})
   io_err = Cint[0]
   nnzj = Cint[0]
-  csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
+  csgr(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun)
   @cutest_error
   return nnzj[1]
@@ -1346,14 +1346,14 @@ end
   - j_fun:   [OUT] Array{Cint, 1}
   - grad:    [IN] Bool
 """
-function ccfsg(n::Int, m::Int, x::Array{Float64, 1}, lj::Int, grad::Bool)
+function ccfsg(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, lj::Int, grad::Bool)
   io_err = Cint[0]
   c = Array(Cdouble, m)
   nnzj = Cint[0]
   j_val = Array(Cdouble, lj)
   j_var = Array(Cint, lj)
   j_fun = Array(Cint, lj)
-  ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
+  ccfsg(cutest_lib, io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
     j_fun, Cint[grad])
   @cutest_error
   return c, nnzj[1], j_val, j_var, j_fun
@@ -1373,12 +1373,12 @@ end
   - j_fun:   [OUT] Array{Cint, 1}
   - grad:    [IN] Bool
 """
-function ccfsg!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1}, lj::Int,
+function ccfsg!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1}, lj::Int,
     j_val::Array{Float64, 1}, j_var::Array{Cint, 1}, j_fun::Array{Cint,
     1}, grad::Bool)
   io_err = Cint[0]
   nnzj = Cint[0]
-  ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
+  ccfsg(cutest_lib, io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
     j_fun, Cint[grad])
   @cutest_error
   return nnzj[1]
@@ -1394,11 +1394,11 @@ end
   - gci:     [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function ccifg(n::Int, icon::Int, x::Array{Float64, 1}, grad::Bool)
+function ccifg(cutest_lib::Ptr{Void}, n::Int, icon::Int, x::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   gci = Array(Cdouble, n)
-  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
+  ccifg(cutest_lib, io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
   @cutest_error
   return ci[1], gci
 end
@@ -1413,11 +1413,11 @@ end
   - gci:     [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
 """
-function ccifg!(n::Int, icon::Int, x::Array{Float64, 1}, gci::Array{Float64, 1},
+function ccifg!(cutest_lib::Ptr{Void}, n::Int, icon::Int, x::Array{Float64, 1}, gci::Array{Float64, 1},
     grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
-  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
+  ccifg(cutest_lib, io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
   @cutest_error
   return ci[1]
 end
@@ -1435,13 +1435,13 @@ end
   - gci_var: [OUT] Array{Cint, 1}
   - grad:    [IN] Bool
 """
-function ccifsg(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int, grad::Bool)
+function ccifsg(cutest_lib::Ptr{Void}, n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   nnzgci = Cint[0]
   gci_val = Array(Cdouble, lgci)
   gci_var = Array(Cint, lgci)
-  ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
+  ccifsg(cutest_lib, io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
     gci_val, gci_var, Cint[grad])
   @cutest_error
   return ci[1], nnzgci[1], gci_val, gci_var
@@ -1460,12 +1460,12 @@ end
   - gci_var: [OUT] Array{Cint, 1}
   - grad:    [IN] Bool
 """
-function ccifsg!(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int,
+function ccifsg!(cutest_lib::Ptr{Void}, n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int,
     gci_val::Array{Float64, 1}, gci_var::Array{Cint, 1}, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   nnzgci = Cint[0]
-  ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
+  ccifsg(cutest_lib, io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
     gci_val, gci_var, Cint[grad])
   @cutest_error
   return ci[1], nnzgci[1]
@@ -1487,13 +1487,13 @@ end
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
 """
-function cgrdh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function cgrdh(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, jtrans::Bool, lj1::Int, lj2::Int, lh1::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   j_val = Array(Cdouble, lj1, lj2)
   h_val = Array(Cdouble, lh1, n)
-  cgrdh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
+  cgrdh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
     Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val)
   @cutest_error
   return g, j_val, h_val
@@ -1515,11 +1515,11 @@ end
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
 """
-function cgrdh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function cgrdh!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, g::Array{Float64, 1}, jtrans::Bool, lj1::Int, lj2::Int,
     j_val::Array{Float64, 2}, lh1::Int, h_val::Array{Float64, 2})
   io_err = Cint[0]
-  cgrdh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
+  cgrdh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
     Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val)
   @cutest_error
   return
@@ -1535,10 +1535,10 @@ end
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
 """
-function cdh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int)
+function cdh(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   h_val = Array(Cdouble, lh1, n)
-  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
+  cdh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return h_val
 end
@@ -1553,10 +1553,10 @@ end
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
 """
-function cdh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int,
+function cdh!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int,
     h_val::Array{Float64, 2})
   io_err = Cint[0]
-  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
+  cdh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return
 end
@@ -1571,10 +1571,10 @@ end
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
 """
-function cdhc(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int)
+function cdhc(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   h_val = Array(Cdouble, lh1, n)
-  cdhc(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
+  cdhc(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return h_val
 end
@@ -1589,10 +1589,10 @@ end
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
 """
-function cdhc!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int,
+function cdhc!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int,
     h_val::Array{Float64, 2})
   io_err = Cint[0]
-  cdhc(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
+  cdhc(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return
 end
@@ -1606,12 +1606,12 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cshp(n::Int, lh::Int)
+function cshp(cutest_lib::Ptr{Void}, n::Int, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  cshp(io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
+  cshp(cutest_lib, io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
   @cutest_error
   return nnzh[1], h_row, h_col
 end
@@ -1625,10 +1625,10 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cshp!(n::Int, lh::Int, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
+function cshp!(cutest_lib::Ptr{Void}, n::Int, lh::Int, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  cshp(io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
+  cshp(cutest_lib, io_err, Cint[n], nnzh, Cint[lh], h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -1646,13 +1646,13 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function csh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int)
+function csh(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
+  csh(cutest_lib, io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
     h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
@@ -1671,12 +1671,12 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function csh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
+function csh!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
     1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
+  csh(cutest_lib, io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
     h_col)
   @cutest_error
   return nnzh[1]
@@ -1695,13 +1695,13 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cshc(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int)
+function cshc(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
+  cshc(cutest_lib, io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
     h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
@@ -1720,12 +1720,12 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cshc!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
+function cshc!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
     1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
+  cshc(cutest_lib, io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
     h_col)
   @cutest_error
   return nnzh[1]
@@ -1748,7 +1748,7 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function ceh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function ceh(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     lhe_ptr::Int, lhe_row::Int, lhe_val::Int, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
@@ -1756,7 +1756,7 @@ function ceh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_val_ptr = Array(Cint, lhe_ptr)
   he_row = Array(Cint, lhe_row)
   he_val = Array(Cdouble, lhe_val)
-  ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
+  ceh(cutest_lib, io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
     Cint[byrows])
   @cutest_error
@@ -1780,13 +1780,13 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function ceh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function ceh!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     lhe_ptr::Int, he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
     lhe_row::Int, he_row::Array{Cint, 1}, lhe_val::Int,
     he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
-  ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
+  ceh(cutest_lib, io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
     Cint[byrows])
   @cutest_error
@@ -1802,10 +1802,10 @@ end
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
 """
-function cidh(n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int)
+function cidh(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int)
   io_err = Cint[0]
   h = Array(Cdouble, lh1, n)
-  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
+  cidh(cutest_lib, io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
   @cutest_error
   return h
 end
@@ -1819,10 +1819,10 @@ end
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
 """
-function cidh!(n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int, h::Array{Float64,
+function cidh!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int, h::Array{Float64,
     2})
   io_err = Cint[0]
-  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
+  cidh(cutest_lib, io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
   @cutest_error
   return
 end
@@ -1839,13 +1839,13 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cish(n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int)
+function cish(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
+  cish(cutest_lib, io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
     h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
@@ -1863,12 +1863,12 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function cish!(n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int,
+function cish!(cutest_lib::Ptr{Void}, n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
     1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
+  cish(cutest_lib, io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
     h_col)
   @cutest_error
   return nnzh[1]
@@ -1893,7 +1893,7 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function csgrsh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function csgrsh(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, lh::Int)
   io_err = Cint[0]
   nnzj = Cint[0]
@@ -1904,7 +1904,7 @@ function csgrsh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
+  csgrsh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun, nnzh[1], h_val, h_row, h_col
@@ -1929,14 +1929,14 @@ end
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
 """
-function csgrsh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function csgrsh!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Cint,
     1}, j_fun::Array{Cint, 1}, lh::Int, h_val::Array{Float64, 1},
     h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   io_err = Cint[0]
   nnzj = Cint[0]
   nnzh = Cint[0]
-  csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
+  csgrsh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzj[1], nnzh[1]
@@ -1965,7 +1965,7 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function csgreh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function csgreh(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, lhe_ptr::Int, lhe_row::Int, lhe_val::Int,
     byrows::Bool)
   io_err = Cint[0]
@@ -1978,7 +1978,7 @@ function csgreh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_val_ptr = Array(Cint, lhe_ptr)
   he_row = Array(Cint, lhe_row)
   he_val = Array(Cdouble, lhe_val)
-  csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
+  csgreh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
     Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
@@ -2008,7 +2008,7 @@ end
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
 """
-function csgreh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
+function csgreh!(cutest_lib::Ptr{Void}, n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Cint,
     1}, j_fun::Array{Cint, 1}, lhe_ptr::Int, he_row_ptr::Array{Cint, 1},
     he_val_ptr::Array{Cint, 1}, lhe_row::Int, he_row::Array{Cint, 1},
@@ -2016,7 +2016,7 @@ function csgreh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   io_err = Cint[0]
   nnzj = Cint[0]
   ne = Cint[0]
-  csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
+  csgreh(cutest_lib, io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
     Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
@@ -2034,11 +2034,11 @@ end
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
 """
-function chprod(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function chprod(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   result = Array(Cdouble, n)
-  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
+  chprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return result
 end
@@ -2054,10 +2054,10 @@ end
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
 """
-function chprod!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function chprod!(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, vector::Array{Float64, 1}, result::Array{Float64, 1})
   io_err = Cint[0]
-  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
+  chprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return
 end
@@ -2077,14 +2077,14 @@ end
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Float64, 1}
 """
-function cshprod(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function cshprod(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, nnz_vector::Int, index_nz_vector::Array{Cint, 1},
     vector::Array{Float64, 1})
   io_err = Cint[0]
   nnz_result = Cint[0]
   index_nz_result = Array(Cint, n)
   result = Array(Cdouble, n)
-  cshprod(io_err, Cint[n], Cint[m], Cint[goth], x, y,
+  cshprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y,
     Cint[nnz_vector], index_nz_vector, vector, nnz_result,
     index_nz_result, result)
   @cutest_error
@@ -2106,13 +2106,13 @@ end
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Float64, 1}
 """
-function cshprod!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function cshprod!(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, nnz_vector::Int, index_nz_vector::Array{Cint, 1},
     vector::Array{Float64, 1}, index_nz_result::Array{Cint, 1},
     result::Array{Float64, 1})
   io_err = Cint[0]
   nnz_result = Cint[0]
-  cshprod(io_err, Cint[n], Cint[m], Cint[goth], x, y,
+  cshprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y,
     Cint[nnz_vector], index_nz_vector, vector, nnz_result,
     index_nz_result, result)
   @cutest_error
@@ -2130,11 +2130,11 @@ end
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
 """
-function chcprod(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function chcprod(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   result = Array(Cdouble, n)
-  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
+  chcprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return result
 end
@@ -2150,10 +2150,10 @@ end
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
 """
-function chcprod!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function chcprod!(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, vector::Array{Float64, 1}, result::Array{Float64, 1})
   io_err = Cint[0]
-  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
+  chcprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return
 end
@@ -2173,14 +2173,14 @@ end
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Float64, 1}
 """
-function cshcprod(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function cshcprod(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, nnz_vector::Int, index_nz_vector::Array{Cint, 1},
     vector::Array{Float64, 1})
   io_err = Cint[0]
   nnz_result = Cint[0]
   index_nz_result = Array(Cint, n)
   result = Array(Cdouble, n)
-  cshcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y,
+  cshcprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y,
     Cint[nnz_vector], index_nz_vector, vector, nnz_result,
     index_nz_result, result)
   @cutest_error
@@ -2202,13 +2202,13 @@ end
   - index_nz_result: [OUT] Array{Cint, 1}
   - result:          [OUT] Array{Float64, 1}
 """
-function cshcprod!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
+function cshcprod!(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
     1}, nnz_vector::Int, index_nz_vector::Array{Cint, 1},
     vector::Array{Float64, 1}, index_nz_result::Array{Cint, 1},
     result::Array{Float64, 1})
   io_err = Cint[0]
   nnz_result = Cint[0]
-  cshcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y,
+  cshcprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, y,
     Cint[nnz_vector], index_nz_vector, vector, nnz_result,
     index_nz_result, result)
   @cutest_error
@@ -2228,11 +2228,11 @@ end
   - result:  [OUT] Array{Float64, 1}
   - lresult: [IN] Int
 """
-function cjprod(n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
+function cjprod(cutest_lib::Ptr{Void}, n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
     vector::Array{Float64, 1}, lvector::Int, lresult::Int)
   io_err = Cint[0]
   result = Array(Cdouble, lresult)
-  cjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
+  cjprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
     vector, Cint[lvector], result, Cint[lresult])
   @cutest_error
   return result
@@ -2251,11 +2251,11 @@ end
   - result:  [OUT] Array{Float64, 1}
   - lresult: [IN] Int
 """
-function cjprod!(n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
+function cjprod!(cutest_lib::Ptr{Void}, n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
     vector::Array{Float64, 1}, lvector::Int, result::Array{Float64, 1},
     lresult::Int)
   io_err = Cint[0]
-  cjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
+  cjprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
     vector, Cint[lvector], result, Cint[lresult])
   @cutest_error
   return
@@ -2278,14 +2278,14 @@ end
   - result:          [OUT] Array{Float64, 1}
   - lresult:         [IN] Int
 """
-function csjprod(n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
+function csjprod(cutest_lib::Ptr{Void}, n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
     nnz_vector::Int, index_nz_vector::Array{Cint, 1},
     vector::Array{Float64, 1}, lvector::Int, lresult::Int)
   io_err = Cint[0]
   nnz_result = Cint[0]
   index_nz_result = Array(Cint, n)
   result = Array(Cdouble, lresult)
-  csjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
+  csjprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
     Cint[nnz_vector], index_nz_vector, vector, Cint[lvector], nnz_result,
     index_nz_result, result, Cint[lresult])
   @cutest_error
@@ -2309,13 +2309,13 @@ end
   - result:          [OUT] Array{Float64, 1}
   - lresult:         [IN] Int
 """
-function csjprod!(n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
+function csjprod!(cutest_lib::Ptr{Void}, n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
     nnz_vector::Int, index_nz_vector::Array{Cint, 1},
     vector::Array{Float64, 1}, lvector::Int, index_nz_result::Array{Cint,
     1}, result::Array{Float64, 1}, lresult::Int)
   io_err = Cint[0]
   nnz_result = Cint[0]
-  csjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
+  csjprod(cutest_lib, io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
     Cint[nnz_vector], index_nz_vector, vector, Cint[lvector], nnz_result,
     index_nz_result, result, Cint[lresult])
   @cutest_error
@@ -2335,12 +2335,12 @@ end
   - chp_ind: [IN] Array{Cint, 1}
   - chp_ptr: [IN] Array{Cint, 1}
 """
-function cchprods(n::Int, m::Int, goth::Bool, x::Array{Float64, 1},
+function cchprods(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1},
     vector::Array{Float64, 1}, lchp::Int, chp_ind::Array{Cint, 1},
     chp_ptr::Array{Cint, 1})
   io_err = Cint[0]
   chp_val = Array(Cdouble, lchp)
-  cchprods(io_err, Cint[n], Cint[m], Cint[goth], x, vector,
+  cchprods(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, vector,
     Cint[lchp], chp_val, chp_ind, chp_ptr)
   @cutest_error
   return chp_val
@@ -2359,11 +2359,11 @@ end
   - chp_ind: [IN] Array{Cint, 1}
   - chp_ptr: [IN] Array{Cint, 1}
 """
-function cchprods!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1},
+function cchprods!(cutest_lib::Ptr{Void}, n::Int, m::Int, goth::Bool, x::Array{Float64, 1},
     vector::Array{Float64, 1}, lchp::Int, chp_val::Array{Float64, 1},
     chp_ind::Array{Cint, 1}, chp_ptr::Array{Cint, 1})
   io_err = Cint[0]
-  cchprods(io_err, Cint[n], Cint[m], Cint[goth], x, vector,
+  cchprods(cutest_lib, io_err, Cint[n], Cint[m], Cint[goth], x, vector,
     Cint[lchp], chp_val, chp_ind, chp_ptr)
   @cutest_error
   return
@@ -2373,9 +2373,9 @@ end
     uterminate()
 
 """
-function uterminate()
+function uterminate(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
-  uterminate(io_err)
+  uterminate(cutest_lib, io_err)
   @cutest_error
   return
 end
@@ -2384,10 +2384,9 @@ end
     cterminate()
 
 """
-function cterminate()
+function cterminate(cutest_lib::Ptr{Void}, )
   io_err = Cint[0]
-  cterminate(io_err)
+  cterminate(cutest_lib, io_err)
   @cutest_error
   return
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,18 +45,18 @@ for p in problems
   fval = [0.0]
   if ncon > 0
     cx = zeros(ncon)
-    cfn(io_err, Cint[nvar], Cint[ncon], x0, fval, cx)
+    cfn(nlp.lib, io_err, Cint[nvar], Cint[ncon], x0, fval, cx)
   else
-    ufn(io_err, Cint[nvar], x0, fval)
+    ufn(nlp.lib, io_err, Cint[nvar], x0, fval)
   end
   println("$p: core interface: f(x₀) = $(fval[1])")
 
   if ncon > 0
     cx = zeros(ncon)
-    println("$p: specialized interface: f(x₀) = $(cfn(nvar, ncon, x0)[1])")
-    println("$p: specialized interface: f(x₀) = $(cfn!(nvar, ncon, x0, cx)[1])")
+    println("$p: specialized interface: f(x₀) = $(cfn(nlp.lib, nvar, ncon, x0)[1])")
+    println("$p: specialized interface: f(x₀) = $(cfn!(nlp.lib, nvar, ncon, x0, cx)[1])")
   else
-    println("$p: specialized interface: f(x₀) = $(ufn(nvar, x0))")
+    println("$p: specialized interface: f(x₀) = $(ufn(nlp.lib, nvar, x0))")
   end
   finalize(nlp)
 end
@@ -80,4 +80,3 @@ end
 
 rm(joinpath(here, "AUTOMAT.d"))
 rm(joinpath(here, "OUTSDIF.d"))
-

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -46,15 +46,15 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
 
   facts("Core interface") do
     if (ncon[1] > 0)
-      cfn(st, nvar, ncon, x0, fx, cx)
+      cfn(nlp.lib, st, nvar, ncon, x0, fx, cx)
       @fact fx[1] --> roughly(f(x0), rtol=rtol)
       @fact cx --> roughly(c(x0), rtol=rtol)
 
-      cofg(st, nvar, x0, fx, gx, True)
+      cofg(nlp.lib, st, nvar, x0, fx, gx, True)
       @fact fx[1] --> roughly(f(x0), rtol=rtol)
       @fact gx --> roughly(g(x0), rtol=rtol)
 
-      cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
+      cofsg(nlp.lib, st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
       @fact fx[1] --> roughly(f(x0), rtol=rtol)
       gx = zeros(nvar[1])
       for i = 1:nnzg[1]
@@ -62,29 +62,29 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       end
       @fact gx --> roughly(g(x0), rtol=rtol)
 
-      ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
+      ccfg(nlp.lib, st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
       @fact Jtx --> roughly(J(x0)', rtol=rtol)
-      ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
+      ccfg(nlp.lib, st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
       @fact Jx --> roughly(J(x0), rtol=rtol)
 
-      clfg(st, nvar, ncon, x0, y0, lx, glx, True)
+      clfg(nlp.lib, st, nvar, ncon, x0, y0, lx, glx, True)
       @fact lx[1] --> roughly(f(x0)+dot(y0,cx), rtol=rtol)
       @fact glx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
 
-      cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
+      cgr(nlp.lib, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Jtx --> roughly(J(x0)', rtol=rtol)
-      cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
+      cgr(nlp.lib, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
-      cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
+      cgr(nlp.lib, st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
       @fact glx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
       @fact Jtx --> roughly(J(x0)', rtol=rtol)
-      cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
+      cgr(nlp.lib, st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
       @fact glx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
 
-      csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
+      csgr(nlp.lib, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
       glx = zeros(nvar[1])
       Jx = zeros(nvar[1], ncon[1])
       for k = 1:nnzj[1]
@@ -96,7 +96,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       end
       @fact glx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
       @fact Jtx --> roughly(J(x0)', rtol=rtol)
-      csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
+      csgr(nlp.lib, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
       gx = zeros(nvar[1])
       Jx = zeros(ncon[1], nvar[1])
       for k = 1:nnzj[1]
@@ -109,7 +109,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
 
-      ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
+      ccfsg(nlp.lib, st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
       Jx = zeros(ncon[1], nvar[1])
       for k = 1:nnzj[1]
         Jx[Jfun[k],Jvar[k]] = Jval[k]
@@ -118,7 +118,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @fact Jx --> roughly(J(x0), rtol=rtol)
 
       for j = 1:ncon[1]
-        ccifg(st, nvar, Cint[j], x0, ci, gci, True)
+        ccifg(nlp.lib, st, nvar, Cint[j], x0, ci, gci, True)
         cx[j] = ci[1]
         Jx[j,:] = gci'
       end
@@ -127,7 +127,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
 
       Jx = zeros(ncon[1], nvar[1])
       for j = 1:ncon[1]
-        ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
+        ccifsg(nlp.lib, st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
         cx[j] = ci[1]
         for k = 1:nnzj[1]
           Jx[j,Jvar[k]] = Jval[k]
@@ -136,31 +136,31 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @fact cx --> roughly(c(x0), rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
 
-      cgrdh(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
+      cgrdh(nlp.lib, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
             Wx)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
-      cgrdh(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
+      cgrdh(nlp.lib, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
             Wx)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Jtx --> roughly(J(x0)', rtol=rtol)
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
-      cgrdh(st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
+      cgrdh(nlp.lib, st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
             Wx)
       @fact gx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
-      cgrdh(st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
+      cgrdh(nlp.lib, st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
             Wx)
       @fact gx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
       @fact Jtx --> roughly(J(x0)', rtol=rtol)
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-      cdh(st, nvar, ncon, x0, y0, nvar, Wx)
+      cdh(nlp.lib, st, nvar, ncon, x0, y0, nvar, Wx)
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-      csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+      csh(nlp.lib, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
       Wx = zeros(nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]; j = Hcol[k];
@@ -169,7 +169,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       end
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-      cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+      cshc(nlp.lib, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
       Cx = zeros(nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]; j = Hcol[k];
@@ -178,17 +178,17 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       end
       @fact Cx --> roughly((W(x0,y0)-H(x0)), rtol=rtol)
 
-      cidh(st, nvar, x0, Cint[0], nvar, Hx)
+      cidh(nlp.lib, st, nvar, x0, Cint[0], nvar, Hx)
       @fact Hx --> roughly(H(x0), rtol=rtol)
       y1 = zeros(ncon[1])
       for k = 1:ncon[1]
-        cidh(st, nvar, x0, Cint[k], nvar, Cx)
+        cidh(nlp.lib, st, nvar, x0, Cint[k], nvar, Cx)
         y1[k] = 1.0
         @fact Cx --> roughly((W(x0,y1)-H(x0)), rtol=rtol)
         y1[k] = 0.0
       end
 
-      cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
+      cish(nlp.lib, st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
       Hx = zeros(nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]; j = Hcol[k];
@@ -198,7 +198,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @fact Hx --> roughly(H(x0), rtol=rtol)
       y1 = zeros(ncon[1])
       for k = 1:ncon[1]
-        cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
+        cish(nlp.lib, st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
         Cx = zeros(nvar[1], nvar[1])
         for k2 = 1:nnzh[1]
           i = Hrow[k2]; j = Hcol[k2];
@@ -210,7 +210,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
         y1[k] = 0.0
       end
 
-      csgrsh(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
+      csgrsh(nlp.lib, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
              lh, Hval, Hrow, Hcol)
       gx = zeros(nvar[1])
       Jx = zeros(ncon[1], nvar[1])
@@ -230,7 +230,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Jx --> roughly(J(x0), rtol=rtol)
       @fact Wx --> roughly(W(x0,y0), rtol=rtol)
-      csgrsh(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
+      csgrsh(nlp.lib, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
              lh, Hval, Hrow, Hcol)
       glx = zeros(nvar[1])
       Jx = zeros(ncon[1], nvar[1])
@@ -253,32 +253,32 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
 
       v = ones(nvar[1])
       Hv = Array(Cdouble, nvar[1])
-      chprod(st, nvar, ncon, False, x0, y0, v, Hv)
+      chprod(nlp.lib, st, nvar, ncon, False, x0, y0, v, Hv)
       @fact Hv --> roughly(W(x0,y0)*v, rtol=rtol)
 
       Hv = Array(Cdouble, nvar[1])
-      chcprod(st, nvar, ncon, False, x0, y0, v, Hv)
+      chcprod(nlp.lib, st, nvar, ncon, False, x0, y0, v, Hv)
       @fact Hv --> roughly((W(x0,y0)-H(x0))*v, rtol=rtol)
 
       v = ones(nvar[1])
       Jv = Array(Cdouble, ncon[1])
-      cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
+      cjprod(nlp.lib, st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
       @fact Jv --> roughly(J(x0)*v, rtol=rtol)
       v = ones(ncon[1])
       Jtv = Array(Cdouble, nvar[1])
-      cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
+      cjprod(nlp.lib, st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
       @fact Jtv --> roughly(J(x0)'*v, rtol=rtol)
     else
-      ufn(st, nvar, x0, fx)
+      ufn(nlp.lib, st, nvar, x0, fx)
       @fact fx[1] --> roughly(f(x0), rtol=rtol)
 
-      ugr(st, nvar, x0, gx)
+      ugr(nlp.lib, st, nvar, x0, gx)
       @fact gx --> roughly(g(x0), rtol=rtol)
 
-      udh(st, nvar, x0, nvar, Hx)
+      udh(nlp.lib, st, nvar, x0, nvar, Hx)
       @fact Hx --> roughly(H(x0), rtol=rtol)
 
-      ush(st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
+      ush(nlp.lib, st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
       Hx = zeros(nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]; j = Hcol[k];
@@ -287,11 +287,11 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       end
       @fact Hx --> roughly(H(x0), rtol=rtol)
 
-      ugrdh(st, nvar, x0, gx, nvar, Hx)
+      ugrdh(nlp.lib, st, nvar, x0, gx, nvar, Hx)
       @fact gx --> roughly(g(x0), rtol=rtol)
       @fact Hx --> roughly(H(x0), rtol=rtol)
 
-      ugrsh(st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
+      ugrsh(nlp.lib, st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
       @fact gx --> roughly(g(x0), rtol=rtol)
       Hx = zeros(nvar[1], nvar[1])
       for k = 1:nnzh[1]
@@ -303,10 +303,10 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
 
       v = ones(nvar[1])
       Hv = Array(Cdouble, nvar[1])
-      uhprod(st, nvar, False, x0, v, Hv)
+      uhprod(nlp.lib, st, nvar, False, x0, v, Hv)
       @fact Hv --> roughly(H(x0)*v, rtol=rtol)
 
-      uofg(st, nvar, x0, fx, gx, True)
+      uofg(nlp.lib, st, nvar, x0, fx, gx, True)
       @fact fx[1] --> roughly(f(x0), rtol=rtol)
       @fact gx --> roughly(g(x0), rtol=rtol)
     end
@@ -314,61 +314,61 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     print("Core interface stress test... ")
     for i = 1:10000
       if (ncon[1] > 0)
-        cfn(st, nvar, ncon, x0, fx, cx)
-        cofg(st, nvar, x0, fx, gx, True)
-        cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
-        ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
-        ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
-        clfg(st, nvar, ncon, x0, y0, lx, glx, True)
-        cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
-        cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
-        cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
-        cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
-        csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
-        csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
-        ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
+        cfn(nlp.lib, st, nvar, ncon, x0, fx, cx)
+        cofg(nlp.lib, st, nvar, x0, fx, gx, True)
+        cofsg(nlp.lib, st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
+        ccfg(nlp.lib, st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
+        ccfg(nlp.lib, st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
+        clfg(nlp.lib, st, nvar, ncon, x0, y0, lx, glx, True)
+        cgr(nlp.lib, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
+        cgr(nlp.lib, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
+        cgr(nlp.lib, st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
+        cgr(nlp.lib, st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
+        csgr(nlp.lib, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
+        csgr(nlp.lib, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
+        ccfsg(nlp.lib, st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
         for j = 1:ncon[1]
-          ccifg(st, nvar, Cint[j], x0, ci, gci, True)
+          ccifg(nlp.lib, st, nvar, Cint[j], x0, ci, gci, True)
         end
         for j = 1:ncon[1]
-          ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
+          ccifsg(nlp.lib, st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
         end
-        cgrdh(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
+        cgrdh(nlp.lib, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
               Wx)
-        cgrdh(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
+        cgrdh(nlp.lib, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
               Wx)
-        cgrdh(st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
+        cgrdh(nlp.lib, st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
               Wx)
-        cgrdh(st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
+        cgrdh(nlp.lib, st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
               Wx)
-        cdh(st, nvar, ncon, x0, y0, nvar, Wx)
-        csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
-        cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
-        cidh(st, nvar, x0, Cint[0], nvar, Hx)
+        cdh(nlp.lib, st, nvar, ncon, x0, y0, nvar, Wx)
+        csh(nlp.lib, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+        cshc(nlp.lib, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+        cidh(nlp.lib, st, nvar, x0, Cint[0], nvar, Hx)
         for k = 1:ncon[1]
-          cidh(st, nvar, x0, Cint[k], nvar, Cx)
+          cidh(nlp.lib, st, nvar, x0, Cint[k], nvar, Cx)
         end
-        cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
+        cish(nlp.lib, st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
         for k = 1:ncon[1]
-          cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
+          cish(nlp.lib, st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
         end
-        csgrsh(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
+        csgrsh(nlp.lib, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
                lh, Hval, Hrow, Hcol)
-        csgrsh(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
+        csgrsh(nlp.lib, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
                lh, Hval, Hrow, Hcol)
-        chprod(st, nvar, ncon, False, x0, y0, v, Hv)
-        chcprod(st, nvar, ncon, False, x0, y0, v, Hv)
-        cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
-        cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
+        chprod(nlp.lib, st, nvar, ncon, False, x0, y0, v, Hv)
+        chcprod(nlp.lib, st, nvar, ncon, False, x0, y0, v, Hv)
+        cjprod(nlp.lib, st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
+        cjprod(nlp.lib, st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
       else
-        ufn(st, nvar, x0, fx)
-        ugr(st, nvar, x0, gx)
-        udh(st, nvar, x0, nvar, Hx)
-        ush(st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
-        ugrdh(st, nvar, x0, gx, nvar, Hx)
-        ugrsh(st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
-        uhprod(st, nvar, False, x0, v, Hv)
-        uofg(st, nvar, x0, fx, gx, True)
+        ufn(nlp.lib, st, nvar, x0, fx)
+        ugr(nlp.lib, st, nvar, x0, gx)
+        udh(nlp.lib, st, nvar, x0, nvar, Hx)
+        ush(nlp.lib, st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
+        ugrdh(nlp.lib, st, nvar, x0, gx, nvar, Hx)
+        ugrsh(nlp.lib, st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
+        uhprod(nlp.lib, st, nvar, False, x0, v, Hv)
+        uofg(nlp.lib, st, nvar, x0, fx, gx, True)
       end
     end
     println("passed")

--- a/test/test_specialized.jl
+++ b/test/test_specialized.jl
@@ -13,63 +13,63 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   v = ones(nlp.meta.nvar)
   facts("Specialized interface") do
     if nlp.meta.ncon > 0
-  fx, cx = cfn(nlp.meta.nvar, nlp.meta.ncon, x0)
+  fx, cx = cfn(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact cx --> roughly(c(x0), rtol=rtol)
 
   cx = zeros(nlp.meta.ncon)
-  fx = cfn!(nlp.meta.nvar, nlp.meta.ncon, x0, cx)
+  fx = cfn!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, cx)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact cx --> roughly(c(x0), rtol=rtol)
 
-  fx, gx = cofg(nlp.meta.nvar, x0, true)
+  fx, gx = cofg(nlp.lib, nlp.meta.nvar, x0, true)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact gx --> roughly(g(x0), rtol=rtol)
 
   gx = zeros(nlp.meta.nvar)
-  fx = cofg!(nlp.meta.nvar, x0, gx, true)
+  fx = cofg!(nlp.lib, nlp.meta.nvar, x0, gx, true)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact gx --> roughly(g(x0), rtol=rtol)
 
-  fx, nnzg, g_val, g_var = cofsg(nlp.meta.nvar, x0, nlp.meta.nvar, true)
+  fx, nnzg, g_val, g_var = cofsg(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar, true)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact g_val[1:nnzg] --> roughly(g(x0)[g_var[1:nnzg]], rtol=rtol)
 
   g_var = zeros(Cint, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
-  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
+  fx, nnzg = cofsg!(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact g_val[1:nnzg] --> roughly(g(x0)[g_var[1:nnzg]], rtol=rtol)
 
-  cx, Jx = ccfg(nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
+  cx, Jx = ccfg(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
   @fact cx --> roughly(c(x0), rtol=rtol)
   @fact Jx --> roughly(J(x0), rtol=rtol)
 
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  ccfg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
+  ccfg!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
   @fact cx --> roughly(c(x0), rtol=rtol)
   @fact Jx --> roughly(J(x0), rtol=rtol)
 
-  fx, gx = clfg(nlp.meta.nvar, nlp.meta.ncon, x0, y0, true)
+  fx, gx = clfg(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, true)
   @fact fx --> roughly(f(x0)+dot(y0,c(x0)), rtol=rtol)
   @fact gx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
 
-  fx = clfg!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true)
+  fx = clfg!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true)
   @fact fx --> roughly(f(x0)+dot(y0,c(x0)), rtol=rtol)
   @fact gx --> roughly(g(x0)+J(x0)'*y0, rtol=rtol)
 
-  gx, Jx = cgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
+  gx, Jx = cgr(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
   @fact gx --> roughly(g(x0), rtol=rtol)
   @fact Jx --> roughly(J(x0), rtol=rtol)
 
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
+  cgr!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
   @fact gx --> roughly(g(x0), rtol=rtol)
   @fact Jx --> roughly(J(x0), rtol=rtol)
 
-  nnzj, Jx, j_var, j_fun = csgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar)
+  nnzj, Jx, j_var, j_fun = csgr(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -81,7 +81,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
+  nnzj = csgr!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -90,7 +90,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   end
   @fact Jx --> roughly(J(x0), rtol=rtol)
 
-  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true)
+  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true)
   @fact cx --> roughly(c(x0), rtol=rtol)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
@@ -103,7 +103,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
+  nnzj = ccfsg!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
   @fact cx --> roughly(c(x0), rtol=rtol)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
@@ -113,20 +113,20 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   @fact Jx --> roughly(J(x0), rtol=rtol)
 
   for j = 1:nlp.meta.ncon
-    ci, gci = ccifg(nlp.meta.nvar, j, x0, true)
+    ci, gci = ccifg(nlp.lib, nlp.meta.nvar, j, x0, true)
     @fact ci --> roughly(c(x0)[j], rtol=rtol)
     @fact gci --> roughly(J(x0)[j,:], rtol=rtol)
   end
 
   for j = 1:nlp.meta.ncon
     gci = zeros(nlp.meta.nvar)
-    ci = ccifg!(nlp.meta.nvar, j, x0, gci, true)
+    ci = ccifg!(nlp.lib, nlp.meta.nvar, j, x0, gci, true)
     @fact ci --> roughly(c(x0)[j], rtol=rtol)
     @fact gci --> roughly(J(x0)[j,:], rtol=rtol)
   end
 
   for j = 1:nlp.meta.ncon
-    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.meta.nvar, j, x0, nlp.meta.nvar, true)
+    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.lib, nlp.meta.nvar, j, x0, nlp.meta.nvar, true)
     @fact ci --> roughly(c(x0)[j], rtol=rtol)
     @fact gci_val --> roughly(J(x0)[j,gci_var], rtol=rtol)
   end
@@ -134,12 +134,12 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   for j = 1:nlp.meta.ncon
     gci_var = zeros(Cint, nlp.meta.nvar)
     gci_val = zeros(nlp.meta.nvar)
-    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
+    ci, nnzgci = ccifsg!(nlp.lib, nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
     @fact ci --> roughly(c(x0)[j], rtol=rtol)
     @fact gci_val --> roughly(J(x0)[j,gci_var], rtol=rtol)
   end
 
-  gx, Jx, Wx = cgrdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
+  gx, Jx, Wx = cgrdh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
   @fact gx --> roughly(g(x0), rtol=rtol)
   @fact Jx --> roughly(J(x0), rtol=rtol)
   @fact Wx --> roughly(W(x0,y0), rtol=rtol)
@@ -147,19 +147,19 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgrdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
+  cgrdh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
   @fact gx --> roughly(g(x0), rtol=rtol)
   @fact Jx --> roughly(J(x0), rtol=rtol)
   @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-  Wx = cdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar)
+  Wx = cdh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar)
   @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
-  cdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx)
+  cdh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx)
   @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-  nnzh, Wx, h_row, h_col = csh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
+  nnzh, Wx, h_row, h_col = csh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -171,7 +171,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
+  nnzh = csh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -180,7 +180,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   end
   @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-  nnzh, Wx, h_row, h_col = cshc(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
+  nnzh, Wx, h_row, h_col = cshc(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -192,7 +192,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
+  nnzh = cshc!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -202,18 +202,18 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   @fact Wx --> roughly(W(x0,y0)-H(x0), rtol=rtol)
 
   for j = 1:nlp.meta.ncon
-    h = cidh(nlp.meta.nvar, x0, j, nlp.meta.nvar)
+    h = cidh(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nvar)
     @fact h --> roughly((W(x0,[i == j ? 1.0 : 0.0 for i = 1:nlp.meta.ncon])-H(x0)), rtol=rtol)
   end
 
   for j = 1:nlp.meta.ncon
     h = zeros(nlp.meta.nvar, nlp.meta.nvar)
-    cidh!(nlp.meta.nvar, x0, j, nlp.meta.nvar, h)
+    cidh!(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nvar, h)
     @fact h --> roughly((W(x0,[i == j ? 1.0 : 0.0 for i = 1:nlp.meta.ncon])-H(x0)), rtol=rtol)
   end
 
   for j = 1:nlp.meta.ncon
-    nnzh, Wx, h_row, h_col = cish(nlp.meta.nvar, x0, j, nlp.meta.nnzh)
+    nnzh, Wx, h_row, h_col = cish(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nnzh)
     w_val = copy(Wx)
     Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
     for k = 1:nnzh
@@ -227,7 +227,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     h_col = zeros(Cint, nlp.meta.nnzh)
     h_row = zeros(Cint, nlp.meta.nnzh)
     Wx = zeros(nlp.meta.nnzh)
-    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
+    nnzh = cish!(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
     w_val = copy(Wx)
     Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
     for k = 1:nnzh
@@ -237,7 +237,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     @fact Wx --> roughly(W(x0,[i == j ? 1.0 : 0.0 for i = 1:nlp.meta.ncon])-H(x0), rtol=rtol)
   end
 
-  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh)
+  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -260,7 +260,7 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
+  nnzj, nnzh = csgrsh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -277,51 +277,51 @@ function test_specinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   end
   @fact Wx --> roughly(W(x0,y0), rtol=rtol)
 
-  result = chprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
+  result = chprod(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   @fact result --> roughly(W(x0,y0)*v, rtol=rtol)
 
   result = zeros(W(x0,y0)*v)
-  chprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
+  chprod!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
 
-  result = chcprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
+  result = chcprod(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   @fact result --> roughly((W(x0,y0)-H(x0))*v, rtol=rtol)
 
   result = zeros((W(x0,y0)-H(x0))*v)
-  chcprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
+  chcprod!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
 
-  result = cjprod(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
+  result = cjprod(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
   @fact result --> roughly(J(x0)*v, rtol=rtol)
 
   result = zeros(J(x0)*v)
-  cjprod!(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
+  cjprod!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
 
 else
-  fx = ufn(nlp.meta.nvar, x0)
+  fx = ufn(nlp.lib, nlp.meta.nvar, x0)
   @fact fx --> roughly(f(x0), rtol=rtol)
 
-  gx = ugr(nlp.meta.nvar, x0)
+  gx = ugr(nlp.lib, nlp.meta.nvar, x0)
   @fact gx --> roughly(g(x0), rtol=rtol)
 
   gx = zeros(nlp.meta.nvar)
-  ugr!(nlp.meta.nvar, x0, gx)
+  ugr!(nlp.lib, nlp.meta.nvar, x0, gx)
   @fact gx --> roughly(g(x0), rtol=rtol)
 
-  fx, gx = uofg(nlp.meta.nvar, x0, true)
+  fx, gx = uofg(nlp.lib, nlp.meta.nvar, x0, true)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact gx --> roughly(g(x0), rtol=rtol)
 
   gx = zeros(nlp.meta.nvar)
-  fx = uofg!(nlp.meta.nvar, x0, gx, true)
+  fx = uofg!(nlp.lib, nlp.meta.nvar, x0, gx, true)
   @fact fx --> roughly(f(x0), rtol=rtol)
   @fact gx --> roughly(g(x0), rtol=rtol)
 
-  h = udh(nlp.meta.nvar, x0, nlp.meta.nvar)
+  h = udh(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar)
   @fact h --> roughly(H(x0), rtol=rtol)
 
-  udh!(nlp.meta.nvar, x0, nlp.meta.nvar, h)
+  udh!(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar, h)
   @fact h --> roughly(H(x0), rtol=rtol)
 
-  nnzh, Wx, h_row, h_col = ush(nlp.meta.nvar, x0, nlp.meta.nnzh)
+  nnzh, Wx, h_row, h_col = ush(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nnzh)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -333,7 +333,7 @@ else
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
+  nnzh = ush!(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -342,11 +342,11 @@ else
   end
   @fact Wx --> roughly(H(x0), rtol=rtol)
 
-  result = uhprod(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar))
+  result = uhprod(nlp.lib, nlp.meta.nvar, false, x0, ones(nlp.meta.nvar))
   @fact result --> roughly(H(x0)*v, rtol=rtol)
 
   result = zeros(H(x0)*v)
-  uhprod!(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result)
+  uhprod!(nlp.lib, nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result)
 
   end
 
@@ -355,116 +355,115 @@ end
 print("Specialized interface stress test... ")
 for i = 1:10000
   if nlp.meta.ncon > 0
-  fx, cx = cfn(nlp.meta.nvar, nlp.meta.ncon, x0)
+  fx, cx = cfn(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0)
   cx = zeros(nlp.meta.ncon)
-  fx = cfn!(nlp.meta.nvar, nlp.meta.ncon, x0, cx)
-  fx, gx = cofg(nlp.meta.nvar, x0, true)
+  fx = cfn!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, cx)
+  fx, gx = cofg(nlp.lib, nlp.meta.nvar, x0, true)
   gx = zeros(nlp.meta.nvar)
-  fx = cofg!(nlp.meta.nvar, x0, gx, true)
-  fx, nnzg, g_val, g_var = cofsg(nlp.meta.nvar, x0, nlp.meta.nvar, true)
+  fx = cofg!(nlp.lib, nlp.meta.nvar, x0, gx, true)
+  fx, nnzg, g_val, g_var = cofsg(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar, true)
   g_var = zeros(Cint, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
-  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
-  cx, Jx = ccfg(nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
+  fx, nnzg = cofsg!(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
+  cx, Jx = ccfg(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  ccfg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
-  fx, gx = clfg(nlp.meta.nvar, nlp.meta.ncon, x0, y0, true)
-  fx = clfg!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true)
-  gx, Jx = cgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
+  ccfg!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
+  fx, gx = clfg(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, true)
+  fx = clfg!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true)
+  gx, Jx = cgr(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
-  nnzj, Jx, j_var, j_fun = csgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar)
+  cgr!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
+  nnzj, Jx, j_var, j_fun = csgr(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
-  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true)
+  nnzj = csgr!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
+  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
+  nnzj = ccfsg!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
   for j = 1:nlp.meta.ncon
-    ci, gci = ccifg(nlp.meta.nvar, j, x0, true)
+    ci, gci = ccifg(nlp.lib, nlp.meta.nvar, j, x0, true)
   end
     gci = zeros(nlp.meta.nvar)
   for j = 1:nlp.meta.ncon
-    ci = ccifg!(nlp.meta.nvar, j, x0, gci, true)
+    ci = ccifg!(nlp.lib, nlp.meta.nvar, j, x0, gci, true)
   end
   for j = 1:nlp.meta.ncon
-    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.meta.nvar, j, x0, nlp.meta.nvar, true)
+    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.lib, nlp.meta.nvar, j, x0, nlp.meta.nvar, true)
   end
     gci_var = zeros(Cint, nlp.meta.nvar)
     gci_val = zeros(nlp.meta.nvar)
   for j = 1:nlp.meta.ncon
-    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
+    ci, nnzgci = ccifsg!(nlp.lib, nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
   end
-  gx, Jx, Wx = cgrdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
+  gx, Jx, Wx = cgrdh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgrdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
-  Wx = cdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar)
+  cgrdh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
+  Wx = cdh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
-  cdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx)
-  nnzh, Wx, h_row, h_col = csh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
+  cdh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx)
+  nnzh, Wx, h_row, h_col = csh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
-  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
-  nnzh, Wx, h_row, h_col = cshc(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
+  nnzh = csh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
+  nnzh, Wx, h_row, h_col = cshc(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
-  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
+  nnzh = cshc!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   for j = 1:nlp.meta.ncon
-    h = cidh(nlp.meta.nvar, x0, j, nlp.meta.nvar)
+    h = cidh(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nvar)
   end
     h = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for j = 1:nlp.meta.ncon
-    cidh!(nlp.meta.nvar, x0, j, nlp.meta.nvar, h)
+    cidh!(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nvar, h)
   end
   for j = 1:nlp.meta.ncon
-    nnzh, Wx, h_row, h_col = cish(nlp.meta.nvar, x0, j, nlp.meta.nnzh)
+    nnzh, Wx, h_row, h_col = cish(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nnzh)
   end
     h_col = zeros(Cint, nlp.meta.nnzh)
     h_row = zeros(Cint, nlp.meta.nnzh)
   for j = 1:nlp.meta.ncon
-    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
+    nnzh = cish!(nlp.lib, nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
   end
-  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh)
+  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
-  result = chprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
+  nnzj, nnzh = csgrsh!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
+  result = chprod(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   result = zeros(W(x0,y0)*v)
-  chprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
-  result = chcprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
+  chprod!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
+  result = chcprod(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   result = zeros((W(x0,y0)-H(x0))*v)
-  chcprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
-  result = cjprod(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
+  chcprod!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
+  result = cjprod(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
   result = zeros(J(x0)*v)
-  cjprod!(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
+  cjprod!(nlp.lib, nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
   else
-  fx = ufn(nlp.meta.nvar, x0)
-  gx = ugr(nlp.meta.nvar, x0)
+  fx = ufn(nlp.lib, nlp.meta.nvar, x0)
+  gx = ugr(nlp.lib, nlp.meta.nvar, x0)
   gx = zeros(nlp.meta.nvar)
-  ugr!(nlp.meta.nvar, x0, gx)
-  fx, gx = uofg(nlp.meta.nvar, x0, true)
+  ugr!(nlp.lib, nlp.meta.nvar, x0, gx)
+  fx, gx = uofg(nlp.lib, nlp.meta.nvar, x0, true)
   gx = zeros(nlp.meta.nvar)
-  fx = uofg!(nlp.meta.nvar, x0, gx, true)
-  h = udh(nlp.meta.nvar, x0, nlp.meta.nvar)
-  udh!(nlp.meta.nvar, x0, nlp.meta.nvar, h)
-  nnzh, Wx, h_row, h_col = ush(nlp.meta.nvar, x0, nlp.meta.nnzh)
+  fx = uofg!(nlp.lib, nlp.meta.nvar, x0, gx, true)
+  h = udh(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar)
+  udh!(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nvar, h)
+  nnzh, Wx, h_row, h_col = ush(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nnzh)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
-  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
-  result = uhprod(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar))
+  nnzh = ush!(nlp.lib, nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
+  result = uhprod(nlp.lib, nlp.meta.nvar, false, x0, ones(nlp.meta.nvar))
   result = zeros(H(x0)*v)
-  uhprod!(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result)
+  uhprod!(nlp.lib, nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result)
   end
 end
 println("passed")
 
 end
-

--- a/test/test_specialized_manual.jl
+++ b/test/test_specialized_manual.jl
@@ -3,58 +3,58 @@ print("Testing non-NLP interface... ")
 outsdif, io_err = "OUTSDIF.d", Cint[0]
 funit = 42
 
-sifdecoder("ROSENBR")
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_open_), Void,
+cutest_lib = sifdecoder("ROSENBR")
+ccall(CUTEst.dlsym(cutest_lib, :fortran_open_), Void,
       (Ptr{Int32}, Ptr{UInt8}, Ptr{Int32}), &funit, outsdif, io_err)
-nvar = Int(udimen(funit))
+nvar = Int(udimen(cutest_lib, funit))
 @assert nvar == 2
-x, bl, bu = usetup(funit, 0, 6, nvar)
+x, bl, bu = usetup(cutest_lib, funit, 0, 6, nvar)
 @assert x == [-1.2, 1.0]
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_close_), Void,
+ccall(CUTEst.dlsym(cutest_lib, :fortran_close_), Void,
       (Ptr{Int32}, Ptr{Int32}), &funit, io_err)
-uterminate()
-Libdl.dlclose(CUTEst.cutest_lib)
+uterminate(cutest_lib, )
+Libdl.dlclose(cutest_lib)
 
-sifdecoder("ROSENBR")
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_open_), Void,
+cutest_lib = sifdecoder("ROSENBR")
+ccall(CUTEst.dlsym(cutest_lib, :fortran_open_), Void,
       (Ptr{Int32}, Ptr{UInt8}, Ptr{Int32}), &funit, outsdif, io_err)
-nvar = Int(udimen(funit))
+nvar = Int(udimen(cutest_lib, funit))
 @assert nvar == 2
-usetup!(funit, 0, 6, nvar, x, bl, bu)
+usetup!(cutest_lib, funit, 0, 6, nvar, x, bl, bu)
 @assert x == [-1.2, 1.0]
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_close_), Void,
+ccall(CUTEst.dlsym(cutest_lib, :fortran_close_), Void,
       (Ptr{Int32}, Ptr{Int32}), &funit, io_err)
-uterminate()
-Libdl.dlclose(CUTEst.cutest_lib)
+uterminate(cutest_lib, )
+Libdl.dlclose(cutest_lib)
 
-sifdecoder("HS35")
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_open_), Void,
+cutest_lib = sifdecoder("HS35")
+ccall(CUTEst.dlsym(cutest_lib, :fortran_open_), Void,
       (Ptr{Int32}, Ptr{UInt8}, Ptr{Int32}), &funit, outsdif, io_err)
-nvar, ncon = map(Int, cdimen(funit))
+nvar, ncon = map(Int, cdimen(cutest_lib, funit))
 @assert (nvar, ncon) === (3, 1)
-x, bl, bu, y, cl, cu, eq, lin = csetup(funit, 0, 6, nvar, ncon, 0, 0, 0)
+x, bl, bu, y, cl, cu, eq, lin = csetup(cutest_lib, funit, 0, 6, nvar, ncon, 0, 0, 0)
 @assert x == [0.5; 0.5; 0.5]
-f, c = cfn(nvar, ncon, x)
+f, c = cfn(cutest_lib, nvar, ncon, x)
 @assert f == 2.25
 @assert c == [1.0]
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_close_), Void,
+ccall(CUTEst.dlsym(cutest_lib, :fortran_close_), Void,
       (Ptr{Int32}, Ptr{Int32}), &funit, io_err)
-cterminate()
-Libdl.dlclose(CUTEst.cutest_lib)
+cterminate(cutest_lib, )
+Libdl.dlclose(cutest_lib)
 
-sifdecoder("HS35")
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_open_), Void,
+cutest_lib = sifdecoder("HS35")
+ccall(CUTEst.dlsym(cutest_lib, :fortran_open_), Void,
       (Ptr{Int32}, Ptr{UInt8}, Ptr{Int32}), &funit, outsdif, io_err)
-nvar, ncon = map(Int, cdimen(funit))
+nvar, ncon = map(Int, cdimen(cutest_lib, funit))
 @assert (nvar, ncon) === (3, 1)
-csetup!(funit, 0, 6, nvar, ncon, x, bl, bu, y, cl, cu, eq, lin, 0, 0, 0)
+csetup!(cutest_lib, funit, 0, 6, nvar, ncon, x, bl, bu, y, cl, cu, eq, lin, 0, 0, 0)
 @assert x == [0.5; 0.5; 0.5]
-f = cfn!(nvar, ncon, x, c)
+f = cfn!(cutest_lib, nvar, ncon, x, c)
 @assert f == 2.25
 @assert c == [1.0]
-ccall(CUTEst.dlsym(CUTEst.cutest_lib, :fortran_close_), Void,
+ccall(CUTEst.dlsym(cutest_lib, :fortran_close_), Void,
       (Ptr{Int32}, Ptr{Int32}), &funit, io_err)
-cterminate()
-Libdl.dlclose(CUTEst.cutest_lib)
+cterminate(cutest_lib, )
+Libdl.dlclose(cutest_lib)
 
 println("done")


### PR DESCRIPTION
I was writing code to test different models in a loop, and got the error "CUTEst: call cutest_finalize on current model first". I followed that advice, and encountered a nasty problem:
- call `CUTEst.cutest_finalize(nlp)`
- load a new problem and begin optimization
- at some random point, Julia's gc runs and triggers the finalizer on the original problem. This sets the global variable `cutest_lib` to `NULL` right in the middle of an optimization. Boom.

I didn't think to just try `finalize`, which would have worked much better. Instead, I reworked this package so that
- Each `nlp` object stores its own lib pointer
- low-level calls pass this pointer to wrappers of the library routines

This eliminates the need to manually call `finalize`. As a side benefit, it also lets you have multiple problems loaded at once. It's a fairly big change, so I'll understand if you don't want it.

The WIP is because the documentation needs to be updated, too.