### PR TITLE
Build CUTEst inside deps/

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -61,6 +61,7 @@ else
             end
           end
         end
+        println(cenv, "ENV[\"CUTEst problems\"] = \"$(pwd())/problems\"")
       end
     end
 
@@ -83,6 +84,7 @@ else
                 path = chomp(split(line, "=")[2])
                 write(cenv, "ENV[\"$var\"] = \"$path\"\n")
               end
+              println(cenv, "ENV[\"CUTEst problems\"] = \"$(pwd())/problems\"")
             end
           end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,15 +70,3 @@ finalize(nlp)
 nlp = CUTEstModel("DIXMAANJ", "-param", "M=30")
 @assert nlp.meta.nvar == 90
 finalize(nlp)
-
-# clean up the test directory
-here = dirname(@__FILE__)
-so_files = filter(x -> (ismatch(r".so$", x) || ismatch(r".dylib$", x)), readdir(here))
-
-for so_file in so_files
-  rm(joinpath(here, so_file))
-end
-
-rm(joinpath(here, "AUTOMAT.d"))
-rm(joinpath(here, "OUTSDIF.d"))
-

--- a/test/test_specialized_manual.jl
+++ b/test/test_specialized_manual.jl
@@ -1,6 +1,6 @@
 print("Testing non-NLP interface... ")
 
-outsdif, io_err = "OUTSDIF.d", Cint[0]
+outsdif, io_err = joinpath(ENV["CUTEst problems"], "OUTSDIF.d"), Cint[0]
 funit = 42
 
 sifdecoder("ROSENBR")


### PR DESCRIPTION
The first commit downloads the files into a directory `deps/files`. After checking for a "global" installation (ref https://github.com/JuliaSmoothOptimizers/CUTEst.jl/issues/103#issuecomment-262296220), it then checks for a "local" (julia-specific) install. Only if the latter is not found does it download and install the files. EDIT: this will avoid unnecessary re-installations whenever you tag a new version of CUTEst (`Pkg.build` runs every time a package gets updated).

The second commit may be more controversial. It adds a new environment variable, `CUTEst problems` which points to the directory `deps/files/problems`. It leverages this to build all the `*.so` files (and the `AUTOMAT.d` and `OUTSDIF.d` files) inside this folder, rather than the user's current folder. I've been deleting `.so` files from various folders that I run CUTEst problems in, so centralizing these files seems like a nice way to prevent clutter. On the other hand, I wonder if it's currently possible to have two different julia sessions running in two different directories, both working on CUTEst problems; if this gets centralized, that won't be possible anymore (I presume). If so, I guess one option would be to build them in a temporary folder, and have each julia session generate a different random temporary.
