### PR TITLE
Bindeps again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
       osx_image: xcode7.3
 
 
+addons:
+  apt_packages:
+    - gfortran
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ branches:
     - master
     - develop
 
-sudo: required
+sudo: false
 
 before_install:
   - if [ `uname` == "Darwin" ]; then brew install gcc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,12 @@ branches:
     - master
     - develop
 
-sudo: false
+sudo: required
 
 before_install:
+  - if [ `uname` == "Linux" ]; then
+    unset DY_LIBRARY_PATH;
+    sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/$(gfortran -dumpversion | cut -f1,2 -d.)/libgfortran.so /usr/local/lib; fi
   - if [ `uname` == "Darwin" ]; then brew install gcc; fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
+BinDeps
 julia 0.4
 Compat 0.7.15
 @osx Homebrew 0.4.0

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,31 @@
-# We don't use BinDeps because we couldn't make it work
-
 using Compat
+using BinDeps
+
+@BinDeps.setup
+
+libgsl = library_dependency("libgsl", aliases=["libgsl-0"])
+
+# package managers - currently with error on sudo
+#   https://discourse.julialang.org/t/installing-dependencies-error-sudo-no-tty-present-and-no-askpass-program-specified/778
+#provides(AptGet, Dict("libgsl0ldbl"=>libgsl, "libgsl0-dev" =>libgsl, "gsl-bin"=>libgsl))
+#provides(Yum, "gsl-devel", libgsl)
+#provides(Pacman, "gsl", libgsl)
+
+if is_apple()
+    if Pkg.installed("Homebrew") === nothing
+        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
+    end
+    using Homebrew
+    provides(Homebrew.HB, "homebrew/versions/gsl1", libgsl, os = :Darwin)
+end
+
+# build from source
+provides(Sources, URI("http://ftp.gnu.org/gnu/gsl/gsl-1.16.tar.gz"), libgsl)
+provides(BuildProcess, Autotools(libtarget = "libgsl.la"), libgsl)
+
+@BinDeps.install Dict(:libgsl => :libgsl)
+
+## BinDeps end
 
 function validate_libcutest()
   env_cutest = get(ENV, "CUTEST", "")
@@ -76,7 +101,7 @@ else
         cd("files") do
           lnxurl = "https://raw.githubusercontent.com/abelsiqueira/linux-cutest/master/install.sh"
           run(`wget $lnxurl -O install.sh`)
-          run(`bash install.sh --install-deps`)
+          run(`bash install.sh`)
 
           open(cutestenv, "w") do cenv
             open("cutest_env.bashrc") do f

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -101,6 +101,7 @@ else
         cd("files") do
           lnxurl = "https://raw.githubusercontent.com/abelsiqueira/linux-cutest/master/install.sh"
           run(`wget $lnxurl -O install.sh`)
+          ENV["C_INCLUDE_PATH"] = joinpath(here, "usr", "include")
           run(`bash install.sh`)
 
           open(cutestenv, "w") do cenv

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,9 +28,22 @@ initial point, the bounds, an so on.
 
 ## Installing
 
-On Linux, you'll need to install `wget`, `gfortran` and `gsl-1.16`. See [this
-page](https://github.com/abelsiqueira/linux-cutest#requirements) for how to
-install the requirements on some linux distributions.
+On Linux, you'll need to install `wget` and `gfortran`, and possibly have to fix the location of `libgfortran.so`.
+
+On Ubuntu 14.04, you can do this with
+```
+sudo apt-get install wget gfortran
+sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/$(gfortran -dumpversion | cut -f1,2 -d.)/libgfortran.so /usr/local/lib
+```
+On Ubuntu 16.04,
+```
+sudo apt-get install wget gfortran
+sudo ln -s /usr/lib/x86_64-linux-gnu/libgfortran.so /usr/local/lib
+```
+On Archlinux, do
+```
+sudo pacman -S wget gfortran
+```
 
 The following commands should automatically download NLPModels.jl and CUTEst,
 and install them.


### PR DESCRIPTION
The latest build fails because of sudo ([discourse](https://discourse.julialang.org/t/installing-dependencies-error-sudo-no-tty-present-and-no-askpass-program-specified/778),
https://github.com/JuliaLang/BinDeps.jl/issues/199)), thwarting my plans of one-commands-install-all.

My current strategy is building `gsl-1.16` using BinDeps, and requiring the user to install `gfortran` separately.

The next steps are to make sure that `libgfortran` is visible, possibly inside `deps`.