### PR TITLE
Make some changes for type stability.

### DIFF
--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -64,7 +64,6 @@ CUTEstException(info :: Integer) = CUTEstException(convert(Int32, info));
 
 macro cutest_error()  # Handle nonzero exit codes.
   esc(:(io_err[1] > 0 && throw(CUTEstException(io_err[1]))))
-  nothing
 end
 
 include("core_interface.jl")

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -64,6 +64,7 @@ CUTEstException(info :: Integer) = CUTEstException(convert(Int32, info));
 
 macro cutest_error()  # Handle nonzero exit codes.
   esc(:(io_err[1] > 0 && throw(CUTEstException(io_err[1]))))
+  nothing
 end
 
 include("core_interface.jl")

--- a/test/test_julia.jl
+++ b/test/test_julia.jl
@@ -41,11 +41,11 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @test isapprox(cx, c(x0), rtol=rtol)
       @test isapprox(Jx, J(x0), rtol=rtol)
 
-      (cx, Jx) = cons(nlp, x0, true);
+      (cx, Jx) = consjac(nlp, x0, true);
       @test isapprox(cx, c(x0), rtol=rtol)
       @test isapprox(Jx, J(x0), rtol=rtol)
 
-      cx = cons(nlp, x0, false)
+      (cx, Jx) = consjac(nlp, x0, false)
       @test isapprox(cx, c(x0), rtol=rtol)
 
       cx = cons(nlp, x0) # This is here to improve coverage
@@ -133,8 +133,8 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
         (fx, cx) = objcons(nlp, x0)
         (cx, jrow, jcol, jval) = cons_coord(nlp, x0, true)
         Jx = sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
-        (cx, Jx) = cons(nlp, x0, true);
-        cx = cons(nlp, x0, false)
+        (cx, Jx) = consjac(nlp, x0, true);
+        cx, Jx = consjac(nlp, x0, false)
         cx = cons(nlp, x0)
         cons!(nlp, x0, cx)
         (jrow, jcol, jval) = jac_coord(nlp, x0)

--- a/test/test_julia.jl
+++ b/test/test_julia.jl
@@ -20,7 +20,7 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     fx = obj(nlp, x0);
     @test isapprox(fx, f(x0), rtol=rtol)
 
-    (fx, gx) = objgrad(nlp, x0, true);
+    (fx, gx) = objgrad(nlp, x0)
     @test isapprox(fx, f(x0), rtol=rtol)
     @test isapprox(gx, g(x0), rtol=rtol)
 
@@ -36,17 +36,14 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       @test isapprox(fx, f(x0), rtol=rtol)
       @test isapprox(cx, c(x0), rtol=rtol)
 
-      (cx, jrow, jcol, jval) = cons_coord(nlp, x0, true)
+      (cx, jrow, jcol, jval) = cons_coord(nlp, x0)
       Jx = sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
       @test isapprox(cx, c(x0), rtol=rtol)
       @test isapprox(Jx, J(x0), rtol=rtol)
 
-      (cx, Jx) = consjac(nlp, x0, true);
+      (cx, Jx) = consjac(nlp, x0)
       @test isapprox(cx, c(x0), rtol=rtol)
       @test isapprox(Jx, J(x0), rtol=rtol)
-
-      (cx, Jx) = consjac(nlp, x0, false)
-      @test isapprox(cx, c(x0), rtol=rtol)
 
       cx = cons(nlp, x0) # This is here to improve coverage
       @test isapprox(cx, c(x0), rtol=rtol)
@@ -102,7 +99,7 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     if nlp.meta.ncon > 0
       @assert nlp.counters.neval_obj == 3
       @assert nlp.counters.neval_grad == 3
-      @assert nlp.counters.neval_cons == 6
+      @assert nlp.counters.neval_cons == 5
       @assert nlp.counters.neval_jac == 4
       @assert nlp.counters.neval_jprod == 1
       @assert nlp.counters.neval_jtprod == 1
@@ -122,7 +119,7 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     print("Julia interface stress test... ")
     for i = 1:10000
       fx = obj(nlp, x0);
-      (fx, gx) = objgrad(nlp, x0, true);
+      (fx, gx) = objgrad(nlp, x0)
       gx = grad(nlp, x0)
       grad!(nlp, x0, gx)
       Hx = hess(nlp, x0);
@@ -131,10 +128,9 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       hprod!(nlp, x0, v, hv)
       if nlp.meta.ncon > 0
         (fx, cx) = objcons(nlp, x0)
-        (cx, jrow, jcol, jval) = cons_coord(nlp, x0, true)
+        (cx, jrow, jcol, jval) = cons_coord(nlp, x0)
         Jx = sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
-        (cx, Jx) = consjac(nlp, x0, true);
-        cx, Jx = consjac(nlp, x0, false)
+        (cx, Jx) = consjac(nlp, x0)
         cx = cons(nlp, x0)
         cons!(nlp, x0, cx)
         (jrow, jcol, jval) = jac_coord(nlp, x0)


### PR DESCRIPTION
I've made some changes to increase type stability, but it didn't improve the timing of the functions.
Not sure if I did something wrong here. The timings are [here](https://gist.github.com/abelsiqueira/613e4794339ab537266368bdc271b2b4).

Changes previous `cons` to `consjac` that returns the constraints and Jacobian, while the currenty `cons` only return the constraints, like `NLPModels`.