### PR TITLE
hess and jac indexes are in Int64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - if [ `uname` == "Linux" ]; then
     unset DY_LIBRARY_PATH;
     sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/$(gfortran -dumpversion | cut -f1,2 -d.)/libgfortran.so /usr/local/lib; fi
-  - if [ `uname` == "Darwin" ]; then brew install gcc; fi
+  - if [ `uname` == "Darwin" ]; then brew update && brew install gcc; fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 
 install:

--- a/src/julia_interface.jl
+++ b/src/julia_interface.jl
@@ -118,7 +118,7 @@ function cons_coord(nlp :: CUTEstModel, x :: Array{Float64,1})
   @cutest_error
   nlp.counters.neval_cons += 1
   nlp.counters.neval_jac += 1
-  return c, jrow, jcol, jval
+  return c, Int.(jrow), Int.(jcol), jval
 end
 
 """
@@ -226,7 +226,7 @@ function hess_coord(nlp :: CUTEstModel, x :: Array{Float64,1}; y :: Array{Float6
                  io_err,     &nvar,      &ncon,      x,            y,            this_nnzh,  &nnzh,      hval,         hrow,       hcol);
     @cutest_error
     nlp.counters.neval_hess += 1
-    return (hcol, hrow, hval)
+    return (Int.(hcol), Int.(hrow), hval)
   end
 
   if ncon > 0
@@ -245,7 +245,7 @@ function hess_coord(nlp :: CUTEstModel, x :: Array{Float64,1}; y :: Array{Float6
 
   obj_weight != 1.0 && (hval[:] *= obj_weight)  # also ok if obj_weight == 0 and ncon == 0
   nlp.counters.neval_hess += 1
-  return (hcol, hrow, hval);  # swap rows and column
+  return (Int.(hcol), Int.(hrow), hval);  # swap rows and column
 end
 
 @doc (@doc NLPModels.hess)


### PR DESCRIPTION
I was testing `cholfact` with `hess`, and it didn't work because `hess` currently returns a `SparseMatrixCSC{Float64,Int32}`, and the `Int32` needs to be `Int64`. Changing only `hess` and not `hess_coord` should also work, what do you think?

Failing code:
```julia
Hx = Symmetric(hess(nlp, x), :L)
F = cholfact(Hx)
```