### PR TITLE
Fix error when nvar * ncon > 32 bit int maximum

### DIFF
--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -171,15 +171,15 @@ function CUTEstModel(name :: String, args...; decode :: Bool=true, verbose ::Boo
   end
   @cutest_error
 
-  nnzh = nnzh[1];
-  nnzj = nnzj[1];
+  nnzh = Int(nnzh[1])
+  nnzj = Int(nnzj[1])
 
   ccall(dlsym(cutest_lib, :fortran_close_), Void,
       (Ptr{Int32}, Ptr{Int32}), &funit, io_err);
   @cutest_error
 
-  meta = NLPModelMeta(nvar, x0=x, lvar=bl, uvar=bu,
-                      ncon=ncon, y0=v, lcon=cl, ucon=cu,
+  meta = NLPModelMeta(Int(nvar), x0=x, lvar=bl, uvar=bu,
+                      ncon=Int(ncon), y0=v, lcon=cl, ucon=cu,
                       nnzj=nnzj, nnzh=nnzh,
                       lin=lin, nln=nln,
                       nlin=nlin, nnln=nnln,


### PR DESCRIPTION
On NLPModels.jl/nlp_types.jl, the definition of nnzj is

    nnzj = max(0, min(nnzj, nvar * ncon))

For BA-L16, nvar * ncon overflows to a negative value, which sets
nnzj = 0.

Closes #139