### PR TITLE
draft single precision support

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -29,12 +29,14 @@ function validate_libcutest()
   tmpdir = mktempdir()
   try
     cd(tmpdir) do
-      outlog = tempname()
-      errlog = tempname()
-      run(pipeline(`$runcutest -p genc -D $hs3`, stdout=outlog, stderr=errlog))
-      print(read(errlog, String))
-      rm(outlog, force=true)
-      rm(errlog, force=true)
+      for prec in ("", "--single")
+        outlog = tempname()
+        errlog = tempname()
+        run(pipeline(`$runcutest -p genc $prec -D $hs3`, stdout=outlog, stderr=errlog))
+        print(read(errlog, String))
+        rm(outlog, force=true)
+        rm(errlog, force=true)
+      end
     end
     return true
   catch

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -109,7 +109,7 @@ else
       cd("files") do
         @info("Installing CUTEst")
 
-        lnxurl = "https://raw.githubusercontent.com/abelsiqueira/linux-cutest/v0.4.1/install.sh"
+        lnxurl = "https://raw.githubusercontent.com/abelsiqueira/linux-cutest/v0.4.2/install.sh"
         run(`wget $lnxurl -O install.sh`)
         ENV["C_INCLUDE_PATH"] = joinpath(here, "usr", "include")
         run(`bash install.sh`)

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -7,6 +7,9 @@ export usetup, csetup, udimen, udimsh, udimse, uvartype, unames,
     cshprod, chcprod, cshcprod, cjprod, csjprod, cchprods, cchprodsp,
     uterminate, cterminate, cifn, cisgr, csgrp, cigr, csgrshp
 
+include("precision_dependent.jl")
+
+
 """# usetup
 The usetup subroutine sets up the correct data structures for
 subsequent computations in the case where the only possible
@@ -23,23 +26,16 @@ Usage:
 
     usetup(io_err, input, out, io_buffer, n, x, x_l, x_u)
 
-  - io_err:    [OUT] Array{Cint, 1}
-  - input:     [IN] Array{Cint, 1}
-  - out:       [IN] Array{Cint, 1}
-  - io_buffer: [IN] Array{Cint, 1}
-  - n:         [IN] Array{Cint, 1}
-  - x:         [OUT] Array{Cdouble, 1}
-  - x_l:       [OUT] Array{Cdouble, 1}
-  - x_u:       [OUT] Array{Cdouble, 1}
+  - io_err:    [OUT] Vector{Cint}
+  - input:     [IN] Vector{Cint}
+  - out:       [IN] Vector{Cint}
+  - io_buffer: [IN] Vector{Cint}
+  - n:         [IN] Vector{Cint}
+  - x:         [OUT] Vector{Cdouble or Cfloat}
+  - x_l:       [OUT] Vector{Cdouble or Cfloat}
+  - x_u:       [OUT] Vector{Cdouble or Cfloat}
 """
-function usetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
-    io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_usetup_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, input, out, io_buffer, n, x, x_l, x_u)
-end
+usetup
 
 """# csetup
 The csetup subroutine sets up the correct data structures for
@@ -60,37 +56,25 @@ Usage:
     csetup(io_err, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn,
 linear, e_order, l_order, v_order)
 
-  - io_err:    [OUT] Array{Cint, 1}
-  - input:     [IN] Array{Cint, 1}
-  - out:       [IN] Array{Cint, 1}
-  - io_buffer: [IN] Array{Cint, 1}
-  - n:         [IN] Array{Cint, 1}
-  - m:         [IN] Array{Cint, 1}
-  - x:         [OUT] Array{Cdouble, 1}
-  - x_l:       [OUT] Array{Cdouble, 1}
-  - x_u:       [OUT] Array{Cdouble, 1}
-  - y:         [OUT] Array{Cdouble, 1}
-  - c_l:       [OUT] Array{Cdouble, 1}
-  - c_u:       [OUT] Array{Cdouble, 1}
-  - equatn:    [OUT] Array{Cint, 1}
-  - linear:    [OUT] Array{Cint, 1}
-  - e_order:   [IN] Array{Cint, 1}
-  - l_order:   [IN] Array{Cint, 1}
-  - v_order:   [IN] Array{Cint, 1}
+  - io_err:    [OUT] Vector{Cint}
+  - input:     [IN] Vector{Cint}
+  - out:       [IN] Vector{Cint}
+  - io_buffer: [IN] Vector{Cint}
+  - n:         [IN] Vector{Cint}
+  - m:         [IN] Vector{Cint}
+  - x:         [OUT] Vector{Cdouble or Cfloat}
+  - x_l:       [OUT] Vector{Cdouble or Cfloat}
+  - x_u:       [OUT] Vector{Cdouble or Cfloat}
+  - y:         [OUT] Vector{Cdouble or Cfloat}
+  - c_l:       [OUT] Vector{Cdouble or Cfloat}
+  - c_u:       [OUT] Vector{Cdouble or Cfloat}
+  - equatn:    [OUT] Vector{Cint}
+  - linear:    [OUT] Vector{Cint}
+  - e_order:   [IN] Vector{Cint}
+  - l_order:   [IN] Vector{Cint}
+  - v_order:   [IN] Vector{Cint}
 """
-function csetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
-    io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1},
-    y::Array{Cdouble, 1}, c_l::Array{Cdouble, 1}, c_u::Array{Cdouble, 1},
-    equatn::Array{Cint, 1}, linear::Array{Cint, 1}, e_order::Array{Cint,
-    1}, l_order::Array{Cint, 1}, v_order::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csetup_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn,
-    linear, e_order, l_order, v_order)
-end
+csetup
 
 """# udimen
 The udimen subroutine discovers how many variables are involved in the
@@ -107,12 +91,12 @@ Usage:
 
     udimen(io_err, input, n)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - input:   [IN] Array{Cint, 1}
-  - n:       [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - input:   [IN] Vector{Cint}
+  - n:       [OUT] Vector{Cint}
 """
-function udimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_udimen_"), Nothing,
+function udimen(io_err::Vector{Cint}, input::Vector{Cint}, n::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_udimen_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, input, n)
 end
@@ -134,11 +118,11 @@ Usage:
 
     udimsh(io_err, nnzh)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
 """
-function udimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_udimsh_"), Nothing,
+function udimsh(io_err::Vector{Cint}, nnzh::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_udimsh_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzh)
 end
@@ -162,14 +146,14 @@ Usage:
 
     udimse(io_err, ne, he_val_ne, he_row_ne)
 
-  - io_err:    [OUT] Array{Cint, 1}
-  - ne:        [OUT] Array{Cint, 1}
-  - he_val_ne: [OUT] Array{Cint, 1}
-  - he_row_ne: [OUT] Array{Cint, 1}
+  - io_err:    [OUT] Vector{Cint}
+  - ne:        [OUT] Vector{Cint}
+  - he_val_ne: [OUT] Vector{Cint}
+  - he_row_ne: [OUT] Vector{Cint}
 """
-function udimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
-    he_row_ne::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_udimse_"), Nothing,
+function udimse(io_err::Vector{Cint}, ne::Vector{Cint}, he_val_ne::Vector{Cint},
+    he_row_ne::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_udimse_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, ne, he_val_ne, he_row_ne)
 end
@@ -190,12 +174,12 @@ Usage:
 
     uvartype(io_err, n, x_type)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x_type:  [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x_type:  [OUT] Vector{Cint}
 """
-function uvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_uvartype_"), Nothing,
+function uvartype(io_err::Vector{Cint}, n::Vector{Cint}, x_type::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_uvartype_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x_type)
 end
@@ -214,16 +198,16 @@ Usage:
 
     unames(io_err, n, pname, vname)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - pname:   [OUT] Array{UInt8, 1}
-  - vname:   [OUT] Array{UInt8, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - pname:   [OUT] Vector{UInt8}
+  - vname:   [OUT] Array{UInt8, 2}
 
 To get useful names, use `String(x)` where `x` can be `pname` or `vname[:,i]`.
 """
-function unames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, pname::Array{UInt8, 1},
+function unames(io_err::Vector{Cint}, n::Vector{Cint}, pname::Vector{UInt8},
     vname::Array{UInt8, 2})
-  ccall(dlsym(cutest_lib, "cutest_unames_"), Nothing,
+  ccall(dlsym(cutest_lib_double, "cutest_unames_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}, Ptr{UInt8}),
     io_err, n, pname, vname)
 end
@@ -244,13 +228,12 @@ Usage:
 
     ureport(io_err, calls, time)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - calls:   [OUT] Array{Cdouble, 1}
-  - time:    [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - calls:   [OUT] Vector{Cdouble}
+  - time:    [OUT] Vector{Cdouble}
 """
-function ureport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
-    1})
-  ccall(dlsym(cutest_lib, "cutest_ureport_"), Nothing,
+function ureport(io_err::Vector{Cint}, calls::Vector{Cdouble}, time::Vector{Cdouble})
+  ccall(dlsym(cutest_lib_double, "cutest_ureport_"), Nothing,
     (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, calls, time)
 end
@@ -273,14 +256,14 @@ Usage:
 
     cdimen(io_err, input, n, m)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - input:   [IN] Array{Cint, 1}
-  - n:       [OUT] Array{Cint, 1}
-  - m:       [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - input:   [IN] Vector{Cint}
+  - n:       [OUT] Vector{Cint}
+  - m:       [OUT] Vector{Cint}
 """
-function cdimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
-    m::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cdimen_"), Nothing,
+function cdimen(io_err::Vector{Cint}, input::Vector{Cint}, n::Vector{Cint},
+    m::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cdimen_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, input, n, m)
 end
@@ -305,11 +288,11 @@ Usage:
 
     cdimsj(io_err, nnzj)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - nnzj:    [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - nnzj:    [OUT] Vector{Cint}
 """
-function cdimsj(io_err::Array{Cint, 1}, nnzj::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cdimsj_"), Nothing,
+function cdimsj(io_err::Vector{Cint}, nnzj::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cdimsj_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzj)
 end
@@ -333,11 +316,11 @@ Usage:
 
     cdimsh(io_err, nnzh)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
 """
-function cdimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cdimsh_"), Nothing,
+function cdimsh(io_err::Vector{Cint}, nnzh::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cdimsh_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzh)
 end
@@ -361,11 +344,11 @@ Usage:
 
     cdimchp(io_err, nnzchp)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - nnzchp:  [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - nnzchp:  [OUT] Vector{Cint}
 """
-function cdimchp(io_err::Array{Cint, 1}, nnzchp::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cdimchp_"), Nothing,
+function cdimchp(io_err::Vector{Cint}, nnzchp::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cdimchp_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzchp)
 end
@@ -391,14 +374,14 @@ Usage:
 
     cdimse(io_err, ne, he_val_ne, he_row_ne)
 
-  - io_err:    [OUT] Array{Cint, 1}
-  - ne:        [OUT] Array{Cint, 1}
-  - he_val_ne: [OUT] Array{Cint, 1}
-  - he_row_ne: [OUT] Array{Cint, 1}
+  - io_err:    [OUT] Vector{Cint}
+  - ne:        [OUT] Vector{Cint}
+  - he_val_ne: [OUT] Vector{Cint}
+  - he_row_ne: [OUT] Vector{Cint}
 """
-function cdimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
-    he_row_ne::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cdimse_"), Nothing,
+function cdimse(io_err::Vector{Cint}, ne::Vector{Cint}, he_val_ne::Vector{Cint},
+    he_row_ne::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cdimse_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, ne, he_val_ne, he_row_ne)
 end
@@ -408,17 +391,16 @@ end
 nonlinear_variables_constraints, equality_constraints,
 linear_constraints)
 
-  - io_err:                          [OUT] Array{Cint, 1}
-  - nonlinear_variables_objective:   [OUT] Array{Cint, 1}
-  - nonlinear_variables_constraints: [OUT] Array{Cint, 1}
-  - equality_constraints:            [OUT] Array{Cint, 1}
-  - linear_constraints:              [OUT] Array{Cint, 1}
+  - io_err:                          [OUT] Vector{Cint}
+  - nonlinear_variables_objective:   [OUT] Vector{Cint}
+  - nonlinear_variables_constraints: [OUT] Vector{Cint}
+  - equality_constraints:            [OUT] Vector{Cint}
+  - linear_constraints:              [OUT] Vector{Cint}
 """
-function cstats(io_err::Array{Cint, 1}, nonlinear_variables_objective::Array{Cint, 1},
-    nonlinear_variables_constraints::Array{Cint, 1},
-    equality_constraints::Array{Cint, 1}, linear_constraints::Array{Cint,
-    1})
-  ccall(dlsym(cutest_lib, "cutest_cstats_"), Nothing,
+function cstats(io_err::Vector{Cint}, nonlinear_variables_objective::Vector{Cint},
+    nonlinear_variables_constraints::Vector{Cint},
+    equality_constraints::Vector{Cint}, linear_constraints::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cstats_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, nonlinear_variables_objective,
     nonlinear_variables_constraints, equality_constraints,
@@ -443,12 +425,12 @@ Usage:
 
     cvartype(io_err, n, x_type)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x_type:  [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x_type:  [OUT] Vector{Cint}
 """
-function cvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cvartype_"), Nothing,
+function cvartype(io_err::Vector{Cint}, n::Vector{Cint}, x_type::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cvartype_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x_type)
 end
@@ -470,19 +452,19 @@ Usage:
 
     cnames(io_err, n, m, pname, vname, cname)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - pname:   [OUT] Array{UInt8, 1}
-  - vname:   [OUT] Array{UInt8, 1}
-  - cname:   [OUT] Array{UInt8, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - pname:   [OUT] Vector{UInt8}
+  - vname:   [OUT] Vector{UInt8}
+  - cname:   [OUT] Vector{UInt8}
 
 To get useful names, use `String(x)` where `x` can be `pname`, `vname[:,i]`,
 or `cname[:,i]`.
 """
-function cnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    pname::Array{UInt8, 1}, vname::Array{UInt8, 2}, cname::Array{UInt8, 2})
-  ccall(dlsym(cutest_lib, "cutest_cnames_"), Nothing,
+function cnames(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+    pname::Vector{UInt8}, vname::Array{UInt8, 2}, cname::Array{UInt8, 2})
+  ccall(dlsym(cutest_lib_double, "cutest_cnames_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}),
     io_err, n, m, pname, vname, cname)
 end
@@ -505,13 +487,12 @@ Usage:
 
     creport(io_err, calls, time)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - calls:   [OUT] Array{Cdouble, 1}
-  - time:    [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - calls:   [OUT] Vector{Cdouble}
+  - time:    [OUT] Vector{Cdouble}
 """
-function creport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
-    1})
-  ccall(dlsym(cutest_lib, "cutest_creport_"), Nothing,
+function creport(io_err::Vector{Cint}, calls::Vector{Cdouble}, time::Vector{Cdouble})
+  ccall(dlsym(cutest_lib_double, "cutest_creport_"), Nothing,
     (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, calls, time)
 end
@@ -533,14 +514,14 @@ Usage:
 
     connames(io_err, m, cname)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - cname:   [OUT] Array{UInt8, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - cname:   [OUT] Vector{UInt8}
 
 To get useful names, use `String(cname[:,i])`.
 """
-function connames(io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{UInt8, 2})
-  ccall(dlsym(cutest_lib, "cutest_connames_"), Nothing,
+function connames(io_err::Vector{Cint}, m::Vector{Cint}, cname::Array{UInt8, 2})
+  ccall(dlsym(cutest_lib_double, "cutest_connames_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
     io_err, m, cname)
 end
@@ -563,12 +544,12 @@ Usage:
 
     pname(io_err, input, pname)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - input:   [IN] Array{Cint, 1}
-  - pname:   [OUT] Array{UInt8, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - input:   [IN] Vector{Cint}
+  - pname:   [OUT] Vector{UInt8}
 """
-function pname(io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{UInt8, 1})
-  ccall(dlsym(cutest_lib, "cutest_pname_"), Nothing,
+function pname(io_err::Vector{Cint}, input::Vector{Cint}, pname::Vector{UInt8})
+  ccall(dlsym(cutest_lib_double, "cutest_pname_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
     io_err, input, pname)
 end
@@ -589,13 +570,13 @@ Usage:
 
     probname(io_err, pname)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - pname:   [OUT] Array{UInt8, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - pname:   [OUT] Vector{UInt8}
 
 To get a useful name, use `String(pname)`.
 """
-function probname(io_err::Array{Cint, 1}, pname::Array{UInt8, 1})
-  ccall(dlsym(cutest_lib, "cutest_probname_"), Nothing,
+function probname(io_err::Vector{Cint}, pname::Vector{UInt8})
+  ccall(dlsym(cutest_lib_double, "cutest_probname_"), Nothing,
     (Ptr{Cint}, Ptr{UInt8}),
     io_err, pname)
 end
@@ -617,14 +598,14 @@ Usage:
 
     varnames(io_err, n, vname)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - vname:   [OUT] Array{UInt8, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - vname:   [OUT] Vector{UInt8}
 
 To get useful names, use `String(vname[:, i])`.
 """
-function varnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{UInt8, 2})
-  ccall(dlsym(cutest_lib, "cutest_varnames_"), Nothing,
+function varnames(io_err::Vector{Cint}, n::Vector{Cint}, vname::Array{UInt8, 2})
+  ccall(dlsym(cutest_lib_double, "cutest_varnames_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
     io_err, n, vname)
 end
@@ -644,17 +625,12 @@ Usage:
 
     ufn(io_err, n, x, f)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
 """
-function ufn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_ufn_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, x, f)
-end
+ufn
 
 """# ugr
 The ugr subroutine evaluates the gradient of the objective function of
@@ -671,17 +647,12 @@ Usage:
 
     ugr(io_err, n, x, g)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - g:       [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
 """
-function ugr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_ugr_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, x, g)
-end
+ugr
 
 """# uofg
 The uofg subroutine evaluates the value of the objective function of
@@ -699,20 +670,14 @@ Usage:
 
     uofg(io_err, n, x, f, g, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - grad:    [IN] Vector{Cint}
 """
-function uofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_uofg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}),
-    io_err, n, x, f, g, grad)
-end
+uofg
 
 """# udh
 The udh subroutine evaluates the Hessian matrix of the objective
@@ -730,18 +695,13 @@ Usage:
 
     udh(io_err, n, x, lh1, h)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - lh1:     [IN] Array{Cint, 1}
-  - h:       [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - lh1:     [IN] Vector{Cint}
+  - h:       [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function udh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_udh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, x, lh1, h)
-end
+udh
 
 """# ushp
 The ushp subroutine evaluates the sparsity pattern of the Hessian
@@ -759,16 +719,16 @@ Usage:
 
     ushp(io_err, n, nnzh, lh, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function ushp(io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ushp_"), Nothing,
+function ushp(io_err::Vector{Cint}, n::Vector{Cint}, nnzh::Vector{Cint},
+    lh::Vector{Cint}, h_row::Vector{Cint}, h_col::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_ushp_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, nnzh, lh, h_row, h_col)
 end
@@ -790,23 +750,16 @@ Usage:
 
     ush(io_err, n, x, nnzh, lh, h_val, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_val:   [OUT] Vector{Cdouble or Cfloat}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function ush(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    nnzh::Array{Cint, 1}, lh::Array{Cint, 1}, h_val::Array{Cdouble, 1},
-    h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ush_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, nnzh, lh, h_val, h_row, h_col)
-end
+ush
 
 """# ueh
 The ueh subroutine evaluates the Hessian matrix of the objective
@@ -827,30 +780,20 @@ Usage:
     ueh(io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
 lhe_val, he_val, byrows)
 
-  - io_err:     [OUT] Array{Cint, 1}
-  - n:          [IN] Array{Cint, 1}
-  - x:          [IN] Array{Cdouble, 1}
-  - ne:         [OUT] Array{Cint, 1}
-  - lhe_ptr:    [IN] Array{Cint, 1}
-  - he_row_ptr: [OUT] Array{Cint, 1}
-  - he_val_ptr: [OUT] Array{Cint, 1}
-  - lhe_row:    [IN] Array{Cint, 1}
-  - he_row:     [OUT] Array{Cint, 1}
-  - lhe_val:    [IN] Array{Cint, 1}
-  - he_val:     [OUT] Array{Cdouble, 1}
-  - byrows:     [IN] Array{Cint, 1}
+  - io_err:     [OUT] Vector{Cint}
+  - n:          [IN] Vector{Cint}
+  - x:          [IN] Vector{Cdouble or Cfloat}
+  - ne:         [OUT] Vector{Cint}
+  - lhe_ptr:    [IN] Vector{Cint}
+  - he_row_ptr: [OUT] Vector{Cint}
+  - he_val_ptr: [OUT] Vector{Cint}
+  - lhe_row:    [IN] Vector{Cint}
+  - he_row:     [OUT] Vector{Cint}
+  - lhe_val:    [IN] Vector{Cint}
+  - he_val:     [OUT] Vector{Cdouble or Cfloat}
+  - byrows:     [IN] Vector{Cint}
 """
-function ueh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint,
-    1}, he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
-    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ueh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-    lhe_val, he_val, byrows)
-end
+ueh
 
 """# ugrdh
 The ugrdh subroutine evaluates the gradient and Hessian matrix of the
@@ -869,20 +812,14 @@ Usage:
 
     ugrdh(io_err, n, x, g, lh1, h)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - lh1:     [IN] Array{Cint, 1}
-  - h:       [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - lh1:     [IN] Vector{Cint}
+  - h:       [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function ugrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_ugrdh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cdouble}),
-    io_err, n, x, g, lh1, h)
-end
+ugrdh
 
 """# ugrsh
 The ugrsh subroutine evaluates the gradient and Hessian matrix of the
@@ -901,24 +838,17 @@ Usage:
 
     ugrsh(io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_val:   [OUT] Vector{Cdouble or Cfloat}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function ugrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
-    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ugrsh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
-end
+ugrsh
 
 """# ugreh
 The ugreh subroutine evaluates the gradient and Hessian matrix of the
@@ -940,32 +870,21 @@ Usage:
     ugreh(io_err, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
 lhe_val, he_val, byrows)
 
-  - io_err:     [OUT] Array{Cint, 1}
-  - n:          [IN] Array{Cint, 1}
-  - x:          [IN] Array{Cdouble, 1}
-  - g:          [OUT] Array{Cdouble, 1}
-  - ne:         [OUT] Array{Cint, 1}
-  - lhe_ptr:    [IN] Array{Cint, 1}
-  - he_row_ptr: [OUT] Array{Cint, 1}
-  - he_val_ptr: [OUT] Array{Cint, 1}
-  - lhe_row:    [IN] Array{Cint, 1}
-  - he_row:     [OUT] Array{Cint, 1}
-  - lhe_val:    [IN] Array{Cint, 1}
-  - he_val:     [OUT] Array{Cdouble, 1}
-  - byrows:     [IN] Array{Cint, 1}
+  - io_err:     [OUT] Vector{Cint}
+  - n:          [IN] Vector{Cint}
+  - x:          [IN] Vector{Cdouble or Cfloat}
+  - g:          [OUT] Vector{Cdouble or Cfloat}
+  - ne:         [OUT] Vector{Cint}
+  - lhe_ptr:    [IN] Vector{Cint}
+  - he_row_ptr: [OUT] Vector{Cint}
+  - he_val_ptr: [OUT] Vector{Cint}
+  - lhe_row:    [IN] Vector{Cint}
+  - he_row:     [OUT] Vector{Cint}
+  - lhe_val:    [IN] Vector{Cint}
+  - he_val:     [OUT] Vector{Cdouble or Cfloat}
+  - byrows:     [IN] Vector{Cint}
 """
-function ugreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1},
-    he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
-    lhe_row::Array{Cint, 1}, he_row::Array{Cint, 1}, lhe_val::Array{Cint,
-    1}, he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ugreh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-    lhe_val, he_val, byrows)
-end
+ugreh
 
 """# uhprod
 The uhprod subroutine forms the product of a vector with the Hessian
@@ -983,21 +902,14 @@ Usage:
 
     uhprod(io_err, n, goth, x, vector, result)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - goth:    [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - vector:  [IN] Array{Cdouble, 1}
-  - result:  [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - goth:    [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - vector:  [IN] Vector{Cdouble or Cfloat}
+  - result:  [OUT] Vector{Cdouble or Cfloat}
 """
-function uhprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
-    x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
-    result::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_uhprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}),
-    io_err, n, goth, x, vector, result)
-end
+uhprod
 
 """# ushprod
 The ushprod subroutine forms the product of a sparse vector with the
@@ -1016,30 +928,20 @@ Usage:
     ushprod(io_err, n, goth, x, nnz_vector, index_nz_vector, vector, nnz_result,
 index_nz_result, result)
 
-  - io_err:          [OUT] Array{Cint, 1}
-  - n:               [IN] Array{Cint, 1}
-  - goth:            [IN] Array{Cint, 1}
-  - x:               [IN] Array{Cdouble, 1}
-  - nnz_vector:      [IN] Array{Cint, 1}
-  - index_nz_vector: [IN] Array{Cint, 1}
-  - vector:          [IN] Array{Cdouble, 1}
-  - nnz_result:      [OUT] Array{Cint, 1}
-  - index_nz_result: [OUT] Array{Cint, 1}
-  - result:          [OUT] Array{Cdouble, 1}
+  - io_err:          [OUT] Vector{Cint}
+  - n:               [IN] Vector{Cint}
+  - goth:            [IN] Vector{Cint}
+  - x:               [IN] Vector{Cdouble or Cfloat}
+  - nnz_vector:      [IN] Vector{Cint}
+  - index_nz_vector: [IN] Vector{Cint}
+  - vector:          [IN] Vector{Cdouble or Cfloat}
+  - nnz_result:      [OUT] Vector{Cint}
+  - index_nz_result: [OUT] Vector{Cint}
+  - result:          [OUT] Vector{Cdouble or Cfloat}
 
 Notice that `vector` and `result` should have allocated dimension of `n`.
 """
-function ushprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
-    x::Array{Cdouble, 1}, nnz_vector::Array{Cint, 1},
-    index_nz_vector::Array{Cint, 1}, vector::Array{Cdouble, 1},
-    nnz_result::Array{Cint, 1}, index_nz_result::Array{Cint, 1},
-    result::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_ushprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, goth, x, nnz_vector, index_nz_vector, vector, nnz_result,
-    index_nz_result, result)
-end
+ushprod
 
 """# ubandh
 The ubandh subroutine extracts the elements which lie within a band of
@@ -1058,22 +960,15 @@ Usage:
 
     ubandh(io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
 
-  - io_err:            [OUT] Array{Cint, 1}
-  - n:                 [IN] Array{Cint, 1}
-  - x:                 [IN] Array{Cdouble, 1}
-  - semibandwidth:     [IN] Array{Cint, 1}
-  - h_band:            [OUT] Array{Cdouble, 2}
-  - lbandh:            [IN] Array{Cint, 1}
-  - max_semibandwidth: [OUT] Array{Cint, 1}
+  - io_err:            [OUT] Vector{Cint}
+  - n:                 [IN] Vector{Cint}
+  - x:                 [IN] Vector{Cdouble or Cfloat}
+  - semibandwidth:     [IN] Vector{Cint}
+  - h_band:            [OUT] Aray{Cdouble or Cfloat, 2}
+  - lbandh:            [IN] Vector{Cint}
+  - max_semibandwidth: [OUT] Vector{Cint}
 """
-function ubandh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    semibandwidth::Array{Cint, 1}, h_band::Array{Cdouble, 2},
-    lbandh::Array{Cint, 1}, max_semibandwidth::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ubandh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
-end
+ubandh
 
 """# cfn
 The cfn subroutine evaluates the value of the objective function and
@@ -1093,20 +988,14 @@ Usage:
 
     cfn(io_err, n, m, x, f, c)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
-  - c:       [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
+  - c:       [OUT] Vector{Cdouble or Cfloat}
 """
-function cfn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, f::Array{Cdouble, 1}, c::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_cfn_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}),
-    io_err, n, m, x, f, c)
-end
+cfn
 
 """# cofg
 The cofg subroutine evaluates the value of the objective function of
@@ -1126,20 +1015,14 @@ Usage:
 
     cofg(io_err, n, x, f, g, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - grad:    [IN] Vector{Cint}
 """
-function cofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cofg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}),
-    io_err, n, x, f, g, grad)
-end
+cofg
 
 """# cofsg
 The cofsg subroutine evaluates the value of the objective function of
@@ -1159,24 +1042,17 @@ Usage:
 
     cofsg(io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
-  - nnzg:    [OUT] Array{Cint, 1}
-  - lg:      [IN] Array{Cint, 1}
-  - g_val:   [OUT] Array{Cdouble, 1}
-  - g_var:   [OUT] Array{Cint, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
+  - nnzg:    [OUT] Vector{Cint}
+  - lg:      [IN] Vector{Cint}
+  - g_val:   [OUT] Vector{Cdouble or Cfloat}
+  - g_var:   [OUT] Vector{Cint}
+  - grad:    [IN] Vector{Cint}
 """
-function cofsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, nnzg::Array{Cint, 1}, lg::Array{Cint, 1},
-    g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cofsg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
-end
+cofsg
 
 """# ccfg
 The ccfg subroutine evaluates the values of the constraint functions
@@ -1196,26 +1072,18 @@ Usage:
 
     ccfg(io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - c:       [OUT] Array{Cdouble, 1}
-  - jtrans:  [IN] Array{Cint, 1}
-  - lcjac1:  [IN] Array{Cint, 1}
-  - lcjac2:  [IN] Array{Cint, 1}
-  - cjac:    [OUT] Array{Cdouble, 2}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - c:       [OUT] Vector{Cdouble or Cfloat}
+  - jtrans:  [IN] Vector{Cint}
+  - lcjac1:  [IN] Vector{Cint}
+  - lcjac2:  [IN] Vector{Cint}
+  - cjac:    [OUT] Aray{Cdouble or Cfloat, 2}
+  - grad:    [IN] Vector{Cint}
 """
-function ccfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, jtrans::Array{Cint, 1},
-    lcjac1::Array{Cint, 1}, lcjac2::Array{Cint, 1}, cjac::Array{Cdouble,
-    2}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ccfg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
-end
+ccfg
 
 """# clfg
 The clfg subroutine evaluates the value of the Lagrangian function
@@ -1235,23 +1103,16 @@ Usage:
 
     clfg(io_err, n, m, x, y, f, g, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - grad:    [IN] Vector{Cint}
 """
-function clfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, f::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_clfg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, y, f, g, grad)
-end
+clfg
 
 """# cgr
 The cgr subroutine evaluates the gradients of the general constraints
@@ -1272,27 +1133,19 @@ Usage:
 
     cgr(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - grlagf:  [IN] Array{Cint, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - jtrans:  [IN] Array{Cint, 1}
-  - lj1:     [IN] Array{Cint, 1}
-  - lj2:     [IN] Array{Cint, 1}
-  - j_val:   [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - grlagf:  [IN] Vector{Cint}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - jtrans:  [IN] Vector{Cint}
+  - lj1:     [IN] Vector{Cint}
+  - lj2:     [IN] Vector{Cint}
+  - j_val:   [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function cgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
-    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_cgr_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
-end
+cgr
 
 """# csgr
 The csgr subroutine evaluates the gradients of the general constraints
@@ -1315,27 +1168,19 @@ Usage:
 
     csgr(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - grlagf:  [IN] Array{Cint, 1}
-  - nnzj:    [OUT] Array{Cint, 1}
-  - lj:      [IN] Array{Cint, 1}
-  - j_val:   [OUT] Array{Cdouble, 1}
-  - j_var:   [OUT] Array{Cint, 1}
-  - j_fun:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - grlagf:  [IN] Vector{Cint}
+  - nnzj:    [OUT] Vector{Cint}
+  - lj:      [IN] Vector{Cint}
+  - j_val:   [OUT] Vector{Cdouble or Cfloat}
+  - j_var:   [OUT] Vector{Cint}
+  - j_fun:   [OUT] Vector{Cint}
 """
-function csgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csgr_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
-end
+csgr
 
 """# ccfsg
 The ccfsg subroutine evaluates the values of the constraint functions
@@ -1356,27 +1201,19 @@ Usage:
 
     ccfsg(io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - c:       [OUT] Array{Cdouble, 1}
-  - nnzj:    [OUT] Array{Cint, 1}
-  - lj:      [IN] Array{Cint, 1}
-  - j_val:   [OUT] Array{Cdouble, 1}
-  - j_var:   [OUT] Array{Cint, 1}
-  - j_fun:   [OUT] Array{Cint, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - c:       [OUT] Vector{Cdouble or Cfloat}
+  - nnzj:    [OUT] Vector{Cint}
+  - lj:      [IN] Vector{Cint}
+  - j_val:   [OUT] Vector{Cdouble or Cfloat}
+  - j_var:   [OUT] Vector{Cint}
+  - j_fun:   [OUT] Vector{Cint}
+  - grad:    [IN] Vector{Cint}
 """
-function ccfsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, nnzj::Array{Cint, 1},
-    lj::Array{Cint, 1}, j_val::Array{Cdouble, 1}, j_var::Array{Cint, 1},
-    j_fun::Array{Cint, 1}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ccfsg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
-end
+ccfsg
 
 """# ccifg
 The ccifg subroutine evaluates the value of a particular constraint
@@ -1397,22 +1234,15 @@ Usage:
 
     ccifg(io_err, n, icon, x, ci, gci, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - icon:    [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - ci:      [OUT] Array{Cdouble, 1}
-  - gci:     [OUT] Array{Cdouble, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - icon:    [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - ci:      [OUT] Vector{Cdouble or Cfloat}
+  - gci:     [OUT] Vector{Cdouble or Cfloat}
+  - grad:    [IN] Vector{Cint}
 """
-function ccifg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
-    x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, gci::Array{Cdouble, 1},
-    grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ccifg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, icon, x, ci, gci, grad)
-end
+ccifg
 
 """# ccifsg
 The ccifsg subroutine evaluates the value of a particular constraint
@@ -1434,26 +1264,18 @@ Usage:
 
     ccifsg(io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - icon:    [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - ci:      [OUT] Array{Cdouble, 1}
-  - nnzgci:  [OUT] Array{Cint, 1}
-  - lgci:    [IN] Array{Cint, 1}
-  - gci_val: [OUT] Array{Cdouble, 1}
-  - gci_var: [OUT] Array{Cint, 1}
-  - grad:    [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - icon:    [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - ci:      [OUT] Vector{Cdouble or Cfloat}
+  - nnzgci:  [OUT] Vector{Cint}
+  - lgci:    [IN] Vector{Cint}
+  - gci_val: [OUT] Vector{Cdouble or Cfloat}
+  - gci_var: [OUT] Vector{Cint}
+  - grad:    [IN] Vector{Cint}
 """
-function ccifsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
-    x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, nnzgci::Array{Cint, 1},
-    lgci::Array{Cint, 1}, gci_val::Array{Cdouble, 1}, gci_var::Array{Cint,
-    1}, grad::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ccifsg_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
-end
+ccifsg
 
 """# cgrdh
 The cgrdh subroutine evaluates the gradients of the general
@@ -1476,31 +1298,21 @@ Usage:
 
     cgrdh(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - grlagf:  [IN] Array{Cint, 1}
-  - g:       [OUT] Array{Cdouble, 1}
-  - jtrans:  [IN] Array{Cint, 1}
-  - lj1:     [IN] Array{Cint, 1}
-  - lj2:     [IN] Array{Cint, 1}
-  - j_val:   [OUT] Array{Cdouble, 2}
-  - lh1:     [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - grlagf:  [IN] Vector{Cint}
+  - g:       [OUT] Vector{Cdouble or Cfloat}
+  - jtrans:  [IN] Vector{Cint}
+  - lj1:     [IN] Vector{Cint}
+  - lj2:     [IN] Vector{Cint}
+  - j_val:   [OUT] Aray{Cdouble or Cfloat, 2}
+  - lh1:     [IN] Vector{Cint}
+  - h_val:   [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function cgrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
-    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_cgrdh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
-end
+cgrdh
 
 """# cdh
 The cdh subroutine evaluates the Hessian matrix of the Lagrangian
@@ -1521,22 +1333,15 @@ Usage:
 
     cdh(io_err, n, m, x, y, lh1, h_val)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - lh1:     [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - lh1:     [IN] Vector{Cint}
+  - h_val:   [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function cdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_cdh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, lh1, h_val)
-end
+cdh
 
 """# cdhc
 The cdhc subroutine evaluates the Hessian matrix of the constraint
@@ -1557,22 +1362,15 @@ Usage:
 
     cdhc(io_err, n, m, x, y, lh1, h_val)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - lh1:     [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - lh1:     [IN] Vector{Cint}
+  - h_val:   [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function cdhc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_cdhc_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, lh1, h_val)
-end
+cdhc
 
 """# cshp
 The cshp subroutine evaluates the sparsity pattern of the Hessian of
@@ -1592,16 +1390,16 @@ Usage:
 
     cshp(io_err, n, nnzh, lh, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function cshp(io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cshp_"), Nothing,
+function cshp(io_err::Vector{Cint}, n::Vector{Cint}, nnzh::Vector{Cint},
+    lh::Vector{Cint}, h_row::Vector{Cint}, h_col::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cshp_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, nnzh, lh, h_row, h_col)
 end
@@ -1625,26 +1423,18 @@ Usage:
 
     csh(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_val:   [OUT] Vector{Cdouble or Cfloat}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function csh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
-end
+csh
 
 """# cshc
 The cshc subroutine evaluates the Hessian matrix of the constraint
@@ -1665,26 +1455,18 @@ Usage:
 
     cshc(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_val:   [OUT] Vector{Cdouble or Cfloat}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function cshc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cshc_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
-end
+cshc
 
 """# ceh
 The ceh subroutine evaluates the Hessian matrix of the Lagrangian
@@ -1708,34 +1490,22 @@ Usage:
     ceh(io_err, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row,
 he_row, lhe_val, he_val, byrows)
 
-  - io_err:     [OUT] Array{Cint, 1}
-  - n:          [IN] Array{Cint, 1}
-  - m:          [IN] Array{Cint, 1}
-  - x:          [IN] Array{Cdouble, 1}
-  - y:          [IN] Array{Cdouble, 1}
-  - ne:         [OUT] Array{Cint, 1}
-  - lhe_ptr:    [IN] Array{Cint, 1}
-  - he_row_ptr: [OUT] Array{Cint, 1}
-  - he_val_ptr: [OUT] Array{Cint, 1}
-  - lhe_row:    [IN] Array{Cint, 1}
-  - he_row:     [OUT] Array{Cint, 1}
-  - lhe_val:    [IN] Array{Cint, 1}
-  - he_val:     [OUT] Array{Cdouble, 1}
-  - byrows:     [IN] Array{Cint, 1}
+  - io_err:     [OUT] Vector{Cint}
+  - n:          [IN] Vector{Cint}
+  - m:          [IN] Vector{Cint}
+  - x:          [IN] Vector{Cdouble or Cfloat}
+  - y:          [IN] Vector{Cdouble or Cfloat}
+  - ne:         [OUT] Vector{Cint}
+  - lhe_ptr:    [IN] Vector{Cint}
+  - he_row_ptr: [OUT] Vector{Cint}
+  - he_val_ptr: [OUT] Vector{Cint}
+  - lhe_row:    [IN] Vector{Cint}
+  - he_row:     [OUT] Vector{Cint}
+  - lhe_val:    [IN] Vector{Cint}
+  - he_val:     [OUT] Vector{Cdouble or Cfloat}
+  - byrows:     [IN] Vector{Cint}
 """
-function ceh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, ne::Array{Cint, 1},
-    lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
-    he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
-    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_ceh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row,
-    he_row, lhe_val, he_val, byrows)
-end
+ceh
 
 """# cidh
 The cidh subroutine evaluates the Hessian matrix of either the
@@ -1756,19 +1526,14 @@ Usage:
 
     cidh(io_err, n, x, iprob, lh1, h)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - iprob:   [IN] Array{Cint, 1}
-  - lh1:     [IN] Array{Cint, 1}
-  - h:       [OUT] Array{Cdouble, 2}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - iprob:   [IN] Vector{Cint}
+  - lh1:     [IN] Vector{Cint}
+  - h:       [OUT] Aray{Cdouble or Cfloat, 2}
 """
-function cidh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    iprob::Array{Cint, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
-  ccall(dlsym(cutest_lib, "cutest_cidh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, x, iprob, lh1, h)
-end
+cidh
 
 """# cish
 The cish subroutine evaluates the Hessian of a particular constraint
@@ -1789,24 +1554,17 @@ Usage:
 
     cish(io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - iprob:   [IN] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - iprob:   [IN] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_val:   [OUT] Vector{Cdouble or Cfloat}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function cish(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    iprob::Array{Cint, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
-    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cish_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
-end
+cish
 
 """# csgrsh
 The csgrsh subroutine evaluates the gradients of the general
@@ -1830,36 +1588,24 @@ Usage:
     csgrsh(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh,
 h_val, h_row, h_col)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - grlagf:  [IN] Array{Cint, 1}
-  - nnzj:    [OUT] Array{Cint, 1}
-  - lj:      [IN] Array{Cint, 1}
-  - j_val:   [OUT] Array{Cdouble, 1}
-  - j_var:   [OUT] Array{Cint, 1}
-  - j_fun:   [OUT] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_val:   [OUT] Array{Cdouble, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - grlagf:  [IN] Vector{Cint}
+  - nnzj:    [OUT] Vector{Cint}
+  - lj:      [IN] Vector{Cint}
+  - j_val:   [OUT] Vector{Cdouble or Cfloat}
+  - j_var:   [OUT] Vector{Cint}
+  - j_fun:   [OUT] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_val:   [OUT] Vector{Cdouble or Cfloat}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint}
 """
-function csgrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csgrsh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh,
-    h_val, h_row, h_col)
-end
+csgrsh
 
 """# csgreh
 The csgreh subroutine evaluates both the gradients of the general
@@ -1887,44 +1633,28 @@ Usage:
 lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val,
 byrows)
 
-  - io_err:     [OUT] Array{Cint, 1}
-  - n:          [IN] Array{Cint, 1}
-  - m:          [IN] Array{Cint, 1}
-  - x:          [IN] Array{Cdouble, 1}
-  - y:          [IN] Array{Cdouble, 1}
-  - grlagf:     [IN] Array{Cint, 1}
-  - nnzj:       [OUT] Array{Cint, 1}
-  - lj:         [IN] Array{Cint, 1}
-  - j_val:      [OUT] Array{Cdouble, 1}
-  - j_var:      [OUT] Array{Cint, 1}
-  - j_fun:      [OUT] Array{Cint, 1}
-  - ne:         [OUT] Array{Cint, 1}
-  - lhe_ptr:    [IN] Array{Cint, 1}
-  - he_row_ptr: [OUT] Array{Cint, 1}
-  - he_val_ptr: [OUT] Array{Cint, 1}
-  - lhe_row:    [IN] Array{Cint, 1}
-  - he_row:     [OUT] Array{Cint, 1}
-  - lhe_val:    [IN] Array{Cint, 1}
-  - he_val:     [OUT] Array{Cdouble, 1}
-  - byrows:     [IN] Array{Cint, 1}
+  - io_err:     [OUT] Vector{Cint}
+  - n:          [IN] Vector{Cint}
+  - m:          [IN] Vector{Cint}
+  - x:          [IN] Vector{Cdouble or Cfloat}
+  - y:          [IN] Vector{Cdouble or Cfloat}
+  - grlagf:     [IN] Vector{Cint}
+  - nnzj:       [OUT] Vector{Cint}
+  - lj:         [IN] Vector{Cint}
+  - j_val:      [OUT] Vector{Cdouble or Cfloat}
+  - j_var:      [OUT] Vector{Cint}
+  - j_fun:      [OUT] Vector{Cint}
+  - ne:         [OUT] Vector{Cint}
+  - lhe_ptr:    [IN] Vector{Cint}
+  - he_row_ptr: [OUT] Vector{Cint}
+  - he_val_ptr: [OUT] Vector{Cint}
+  - lhe_row:    [IN] Vector{Cint}
+  - he_row:     [OUT] Vector{Cint}
+  - lhe_val:    [IN] Vector{Cint}
+  - he_val:     [OUT] Vector{Cdouble or Cfloat}
+  - byrows:     [IN] Vector{Cint}
 """
-function csgreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, ne::Array{Cint, 1},
-    lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
-    he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
-    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csgreh_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne,
-    lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val,
-    byrows)
-end
+csgreh
 
 """# chprod
 The chprod subroutine forms the product of a vector with the Hessian
@@ -1945,23 +1675,16 @@ Usage:
 
     chprod(io_err, n, m, goth, x, y, vector, result)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - goth:    [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - vector:  [IN] Array{Cdouble, 1}
-  - result:  [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - goth:    [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - vector:  [IN] Vector{Cdouble or Cfloat}
+  - result:  [OUT] Vector{Cdouble or Cfloat}
 """
-function chprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_chprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, m, goth, x, y, vector, result)
-end
+chprod
 
 """# cshprod
 The cshprod subroutine forms the product of a sparse vector with the
@@ -1983,33 +1706,22 @@ Usage:
     cshprod(io_err, n, m, goth, x, y, nnz_vector, index_nz_vector, vector,
 nnz_result, index_nz_result, result)
 
-  - io_err:          [OUT] Array{Cint, 1}
-  - n:               [IN] Array{Cint, 1}
-  - m:               [IN] Array{Cint, 1}
-  - goth:            [IN] Array{Cint, 1}
-  - x:               [IN] Array{Cdouble, 1}
-  - y:               [IN] Array{Cdouble, 1}
-  - nnz_vector:      [IN] Array{Cint, 1}
-  - index_nz_vector: [IN] Array{Cint, 1}
-  - vector:          [IN] Array{Cdouble, 1}
-  - nnz_result:      [OUT] Array{Cint, 1}
-  - index_nz_result: [OUT] Array{Cint, 1}
-  - result:          [OUT] Array{Cdouble, 1}
+  - io_err:          [OUT] Vector{Cint}
+  - n:               [IN] Vector{Cint}
+  - m:               [IN] Vector{Cint}
+  - goth:            [IN] Vector{Cint}
+  - x:               [IN] Vector{Cdouble or Cfloat}
+  - y:               [IN] Vector{Cdouble or Cfloat}
+  - nnz_vector:      [IN] Vector{Cint}
+  - index_nz_vector: [IN] Vector{Cint}
+  - vector:          [IN] Vector{Cdouble or Cfloat}
+  - nnz_result:      [OUT] Vector{Cint}
+  - index_nz_result: [OUT] Vector{Cint}
+  - result:          [OUT] Vector{Cdouble or Cfloat}
 
 Notice that `vector` and `result` should have allocated dimension of `n`.
 """
-function cshprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    nnz_vector::Array{Cint, 1}, index_nz_vector::Array{Cint, 1},
-    vector::Array{Cdouble, 1}, nnz_result::Array{Cint, 1},
-    index_nz_result::Array{Cint, 1}, result::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_cshprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, goth, x, y, nnz_vector, index_nz_vector, vector,
-    nnz_result, index_nz_result, result)
-end
+cshprod
 
 """# chcprod
 The chcprod subroutine forms the product of a vector with the Hessian
@@ -2030,23 +1742,16 @@ Usage:
 
     chcprod(io_err, n, m, goth, x, y, vector, result)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - goth:    [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - y:       [IN] Array{Cdouble, 1}
-  - vector:  [IN] Array{Cdouble, 1}
-  - result:  [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - goth:    [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - y:       [IN] Vector{Cdouble or Cfloat}
+  - vector:  [IN] Vector{Cdouble or Cfloat}
+  - result:  [OUT] Vector{Cdouble or Cfloat}
 """
-function chcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_chcprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, m, goth, x, y, vector, result)
-end
+chcprod
 
 """# cshcprod
 The cshcprod subroutine forms the product of a sparse vector with the
@@ -2068,31 +1773,20 @@ Usage:
     cshcprod(io_err, n, m, goth, x, y, nnz_vector, index_nz_vector, vector,
 nnz_result, index_nz_result, result)
 
-  - io_err:          [OUT] Array{Cint, 1}
-  - n:               [IN] Array{Cint, 1}
-  - m:               [IN] Array{Cint, 1}
-  - goth:            [IN] Array{Cint, 1}
-  - x:               [IN] Array{Cdouble, 1}
-  - y:               [IN] Array{Cdouble, 1}
-  - nnz_vector:      [IN] Array{Cint, 1}
-  - index_nz_vector: [IN] Array{Cint, 1}
-  - vector:          [IN] Array{Cdouble, 1}
-  - nnz_result:      [OUT] Array{Cint, 1}
-  - index_nz_result: [OUT] Array{Cint, 1}
-  - result:          [OUT] Array{Cdouble, 1}
+  - io_err:          [OUT] Vector{Cint}
+  - n:               [IN] Vector{Cint}
+  - m:               [IN] Vector{Cint}
+  - goth:            [IN] Vector{Cint}
+  - x:               [IN] Vector{Cdouble or Cfloat}
+  - y:               [IN] Vector{Cdouble or Cfloat}
+  - nnz_vector:      [IN] Vector{Cint}
+  - index_nz_vector: [IN] Vector{Cint}
+  - vector:          [IN] Vector{Cdouble or Cfloat}
+  - nnz_result:      [OUT] Vector{Cint}
+  - index_nz_result: [OUT] Vector{Cint}
+  - result:          [OUT] Vector{Cdouble or Cfloat}
 """
-function cshcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    nnz_vector::Array{Cint, 1}, index_nz_vector::Array{Cint, 1},
-    vector::Array{Cdouble, 1}, nnz_result::Array{Cint, 1},
-    index_nz_result::Array{Cint, 1}, result::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_cshcprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, goth, x, y, nnz_vector, index_nz_vector, vector,
-    nnz_result, index_nz_result, result)
-end
+cshcprod
 
 """# cjprod
 The cjprod subroutine forms the product of a vector with the Jacobian
@@ -2113,26 +1807,18 @@ Usage:
 
     cjprod(io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - gotj:    [IN] Array{Cint, 1}
-  - jtrans:  [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - vector:  [IN] Array{Cdouble, 1}
-  - lvector: [IN] Array{Cint, 1}
-  - result:  [OUT] Array{Cdouble, 1}
-  - lresult: [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - gotj:    [IN] Vector{Cint}
+  - jtrans:  [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - vector:  [IN] Vector{Cdouble or Cfloat}
+  - lvector: [IN] Vector{Cint}
+  - result:  [OUT] Vector{Cdouble or Cfloat}
+  - lresult: [IN] Vector{Cint}
 """
-function cjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
-    result::Array{Cdouble, 1}, lresult::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cjprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
-end
+cjprod
 
 """# csjprod
 The csjprod subroutine forms the product of a sparse vector with the
@@ -2154,34 +1840,22 @@ Usage:
     csjprod(io_err, n, m, gotj, jtrans, x, nnz_vector, index_nz_vector, vector,
 lvector, nnz_result, index_nz_result, result, lresult)
 
-  - io_err:          [OUT] Array{Cint, 1}
-  - n:               [IN] Array{Cint, 1}
-  - m:               [IN] Array{Cint, 1}
-  - gotj:            [IN] Array{Cint, 1}
-  - jtrans:          [IN] Array{Cint, 1}
-  - x:               [IN] Array{Cdouble, 1}
-  - nnz_vector:      [IN] Array{Cint, 1}
-  - index_nz_vector: [IN] Array{Cint, 1}
-  - vector:          [IN] Array{Cdouble, 1}
-  - lvector:         [IN] Array{Cint, 1}
-  - nnz_result:      [OUT] Array{Cint, 1}
-  - index_nz_result: [OUT] Array{Cint, 1}
-  - result:          [OUT] Array{Cdouble, 1}
-  - lresult:         [IN] Array{Cint, 1}
+  - io_err:          [OUT] Vector{Cint}
+  - n:               [IN] Vector{Cint}
+  - m:               [IN] Vector{Cint}
+  - gotj:            [IN] Vector{Cint}
+  - jtrans:          [IN] Vector{Cint}
+  - x:               [IN] Vector{Cdouble or Cfloat}
+  - nnz_vector:      [IN] Vector{Cint}
+  - index_nz_vector: [IN] Vector{Cint}
+  - vector:          [IN] Vector{Cdouble or Cfloat}
+  - lvector:         [IN] Vector{Cint}
+  - nnz_result:      [OUT] Vector{Cint}
+  - index_nz_result: [OUT] Vector{Cint}
+  - result:          [OUT] Vector{Cdouble or Cfloat}
+  - lresult:         [IN] Vector{Cint}
 """
-function csjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
-    nnz_vector::Array{Cint, 1}, index_nz_vector::Array{Cint, 1},
-    vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
-    nnz_result::Array{Cint, 1}, index_nz_result::Array{Cint, 1},
-    result::Array{Cdouble, 1}, lresult::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csjprod_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, gotj, jtrans, x, nnz_vector, index_nz_vector, vector,
-    lvector, nnz_result, index_nz_result, result, lresult)
-end
+csjprod
 
 """# cchprods
 The cchprods subroutine forms the product of a vector with each of the
@@ -2202,26 +1876,18 @@ Usage:
 
     cchprods(io_err, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - goth:    [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - vector:  [IN] Array{Cdouble, 1}
-  - lchp:    [IN] Array{Cint, 1}
-  - chp_val: [OUT] Array{Cdouble, 1}
-  - chp_ind: [IN] Array{Cint, 1}
-  - chp_ptr: [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - goth:    [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - vector:  [IN] Vector{Cdouble or Cfloat}
+  - lchp:    [IN] Vector{Cint}
+  - chp_val: [OUT] Vector{Cdouble or Cfloat}
+  - chp_ind: [IN] Vector{Cint}
+  - chp_ptr: [IN] Vector{Cint}
 """
-function cchprods(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
-    lchp::Array{Cint, 1}, chp_val::Array{Cdouble, 1}, chp_ind::Array{Cint,
-    1}, chp_ptr::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cchprods_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
-end
+cchprods
 
 """# cchprodsp
 The cchprodsp subroutine obtains the sparsity structure used when forming the
@@ -2233,18 +1899,19 @@ Usage:
 
     cchprodsp(io_err, m, lchp, chp_ind, chp_ptr)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - m:       [IN] Array{Cint, 1}
-  - lchp:    [IN] Array{Cint, 1}
-  - chp_ind: [IN] Array{Cint, 1}
-  - chp_ptr: [IN] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - m:       [IN] Vector{Cint}
+  - lchp:    [IN] Vector{Cint}
+  - chp_ind: [IN] Vector{Cint}
+  - chp_ptr: [IN] Vector{Cint}
 """
-function cchprodsp(io_err::Array{Cint, 1}, m::Array{Cint, 1}, lchp::Array{Cint, 1},
-    chp_ind::Array{Cint, 1}, chp_ptr::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cchprodsp_"), Nothing,
+function cchprodsp(io_err::Vector{Cint}, m::Vector{Cint}, lchp::Vector{Cint},
+    chp_ind::Vector{Cint}, chp_ptr::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cchprodsp_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, m, lchp, chp_ind, chp_ptr)
 end
+
 
 """# uterminate
 The uterminate subroutine deallocates all workspace arrays created
@@ -2258,10 +1925,10 @@ Usage:
 
     uterminate(io_err)
 
-  - io_err:  [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
 """
-function uterminate(io_err::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_uterminate_"), Nothing,
+function uterminate(io_err::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_uterminate_"), Nothing,
     (Ptr{Cint},),
     io_err)
 end
@@ -2278,10 +1945,10 @@ Usage:
 
     cterminate(io_err)
 
-  - io_err:  [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
 """
-function cterminate(io_err::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cterminate_"), Nothing,
+function cterminate(io_err::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_cterminate_"), Nothing,
     (Ptr{Cint},),
     io_err)
 end
@@ -2297,20 +1964,15 @@ For more information, run the shell command
 
 Usage:
 
-    
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - iprob:   [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - f:       [OUT] Array{Cdouble, 1}
+
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - iprob:   [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - f:       [OUT] Vector{Cdouble or Cfloat}
 """
-function cifn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, iprob::Array{Cint, 1},
-    x::Array{Cdouble, 1}, f::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_cifn_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, iprob, x, f)
-end
+cifn
 
 """# cisgr
 The cisgr subroutine evaluates the gradient of either the objective function or
@@ -2324,23 +1986,16 @@ For more information, run the shell command
 
 Usage:
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - iprob:   [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - nnzg:    [OUT] Array{Cint, 1}
-  - lg:      [IN] Array{Cint, 1}
-  - g_val:   [OUT] Array{Cdouble, 1}
-  - g_var:   [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - iprob:   [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - nnzg:    [OUT] Vector{Cint}
+  - lg:      [IN] Vector{Cint}
+  - g_val:   [OUT] Vector{Cdouble or Cfloat}
+  - g_var:   [OUT] Vector{Cint}
 """
-function cisgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, iprod::Array{Cint, 1},
-    x::Array{Cdouble, 1}, nnzg::Array{Cint, 1}, lg::Array{Cint, 1},
-    g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_cisgr_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-     Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, iprod, x, nnzg, lg, g_val, g_var)
-end
+cisgr
 
 """# csgrp
 The csgrp subroutine evaluates sparsity pattern used when storing the gradients
@@ -2356,16 +2011,16 @@ Usage:
 
     csgrp(io_err, n, nnzj, lj, j_var, j_fun)
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - nnzj:       [OUT] Array{Cint, 1}
-  - lj:         [IN] Array{Cint, 1}
-  - j_var:      [OUT] Array{Cint, 1}
-  - j_fun:      [OUT] Array{Cint, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - nnzj:    [OUT] Vector{Cint}
+  - lj:      [IN] Vector{Cint}
+  - j_var:   [OUT] Vector{Cint}
+  - j_fun:   [OUT] Vector{Cint}
 """
-function csgrp(io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzj::Array{Cint, 1},
-    lj::Array{Cint, 1}, j_var::Array{Cint, 1}, j_fun::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csgrp_"), Nothing,
+function csgrp(io_err::Vector{Cint}, n::Vector{Cint}, nnzj::Vector{Cint},
+    lj::Vector{Cint}, j_var::Vector{Cint}, j_fun::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_csgrp_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, nnzj, lj, j_var, j_fun)
 end
@@ -2379,18 +2034,13 @@ For more information, run the shell command
 
     man cutest_cigr
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - iprob:   [IN] Array{Cint, 1}
-  - x:       [IN] Array{Cdouble, 1}
-  - g_val:   [OUT] Array{Cdouble, 1}
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - iprob:   [IN] Vector{Cint}
+  - x:       [IN] Vector{Cdouble or Cfloat}
+  - g_val:   [OUT] Vector{Cdouble or Cfloat}
 """
-function cigr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, iprob::Array{Cint, 1},
-    x::Array{Cdouble, 1}, g_val::Array{Cdouble, 1})
-  ccall(dlsym(cutest_lib, "cutest_cigr_"), Nothing,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, iprob, x, g_val)
-end
+cigr
 
 """# csgrshp
 The csgrshp subroutine evaluates sparsity pattern used when storing the
@@ -2403,21 +2053,21 @@ For more information, run the shell command
 
     man cutest_csgrshp
 
-  - io_err:  [OUT] Array{Cint, 1}
-  - n:       [IN] Array{Cint, 1}
-  - nnzj:    [OUT] Array{Cint, 1};
-  - lj:      [IN] Array{Cint, 1}
-  - j_var:   [OUT] Array{Cint, 1}
-  - j_fun:   [OUT] Array{Cint, 1}
-  - nnzh:    [OUT] Array{Cint, 1}
-  - lh:      [IN] Array{Cint, 1}
-  - h_row:   [OUT] Array{Cint, 1}
-  - h_col:   [OUT] Array{Cint, 1};
+  - io_err:  [OUT] Vector{Cint}
+  - n:       [IN] Vector{Cint}
+  - nnzj:    [OUT] Vector{Cint};
+  - lj:      [IN] Vector{Cint}
+  - j_var:   [OUT] Vector{Cint}
+  - j_fun:   [OUT] Vector{Cint}
+  - nnzh:    [OUT] Vector{Cint}
+  - lh:      [IN] Vector{Cint}
+  - h_row:   [OUT] Vector{Cint}
+  - h_col:   [OUT] Vector{Cint};
 """
-function csgrshp(io_err::Array{Cint, 1}, n::Array{Cint, 1}, nnzj::Array{Cint, 1},
-    lj::Array{Cint, 1}, j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
-  ccall(dlsym(cutest_lib, "cutest_csgrshp_"), Nothing,
+function csgrshp(io_err::Vector{Cint}, n::Vector{Cint}, nnzj::Vector{Cint},
+    lj::Vector{Cint}, j_var::Vector{Cint}, j_fun::Vector{Cint}, nnzh::Vector{Cint},
+    lh::Vector{Cint}, h_row::Vector{Cint}, h_col::Vector{Cint})
+  ccall(dlsym(cutest_lib_double, "cutest_csgrshp_"), Nothing,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
      Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)

--- a/src/julia_interface.jl
+++ b/src/julia_interface.jl
@@ -4,84 +4,86 @@ using NLPModels, SparseArrays
 
 @doc (@doc NLPModels.objcons)
 function NLPModels.objcons(nlp :: CUTEstModel, x :: AbstractVector)
-  c = Array{Float64}(undef, nlp.meta.ncon);
+  c = Vector{eltype(x)}(undef, nlp.meta.ncon)
   objcons!(nlp, x, c)
-end
-
-@doc (@doc NLPModels.objcons!)
-function NLPModels.objcons!(nlp :: CUTEstModel, x :: Array{Float64,1}, c :: Array{Float64,1})
-  nvar = nlp.meta.nvar;
-  ncon = nlp.meta.ncon;
-  io_err = Cint[0];
-  f = Cdouble[0];
-  if ncon > 0
-    ccall(dlsym(cutest_lib, :cutest_cfn_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
-                 io_err,  nvar,   ncon,   x,         f,         c);
-    nlp.counters.neval_cons += 1
-  else
-    ccall(dlsym(cutest_lib, :cutest_ufn_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}),
-                 io_err,  nvar,    x,         f);
-  end
-  nlp.counters.neval_obj += 1
-  @cutest_error
-
-  return f[1], c
-end
-
-function NLPModels.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: Array{Float64,1})
-  objcons!(nlp, Vector{Float64}(x), c)
-end
-
-function NLPModels.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: AbstractVector)
-  m = nlp.meta.ncon
-  if m > 0
-    cc = zeros(m)
-    f, _ = objcons!(nlp, Vector{Float64}(x), cc)
-    c .= cc
-    return f, c
-  else
-    return objcons!(nlp, Vector{Float64}(x), zeros(0))
-  end
 end
 
 @doc (@doc NLPModels.objgrad)
 function NLPModels.objgrad(nlp :: CUTEstModel, x :: AbstractVector)
-  g = Array{Float64}(undef, nlp.meta.nvar);
+  g = Vector{eltype(x)}(undef, nlp.meta.nvar)
   objgrad!(nlp, x, g)
 end
 
-@doc (@doc NLPModels.objgrad!)
-function NLPModels.objgrad!(nlp :: CUTEstModel, x :: Array{Float64,1}, g :: Array{Float64,1})
-  nvar = nlp.meta.nvar;
-  ncon = nlp.meta.ncon;
-  f = Cdouble[0];
-  io_err = Cint[0];
-  get_grad = 1;
-  if ncon > 0
-    ccall(dlsym(cutest_lib, "cutest_cofg_"), Nothing,
-        (Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{Int32}),
-             io_err,       nvar,            x,            f,            g,   get_grad);
-  else
-    ccall(dlsym(cutest_lib, "cutest_uofg_"), Nothing,
-        (Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{Int32}),
-             io_err,       nvar,            x,            f,            g,   get_grad);
+# generate single and double-precision variants
+for (typ, ctyp, cutest_lib) in ((Float64, Cdouble, :cutest_lib_double),
+                                (Float32, Cfloat, :cutest_lib_single))
+
+  @eval begin
+    function NLPModels.objcons!(nlp :: CUTEstModel, x :: Vector{$typ}, c :: Vector{$typ})
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      io_err = Cint[0]
+      f = $(ctyp)[0]
+      if ncon > 0
+        ccall(dlsym(eval($cutest_lib), :cutest_cfn_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}),
+                     io_err,     nvar,       ncon,       x,         f,         c)
+        nlp.counters.neval_cons += 1
+      else
+        ccall(dlsym(eval($cutest_lib), :cutest_ufn_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}),
+                     io_err,     nvar,       x,         f)
+      end
+      nlp.counters.neval_obj += 1
+      @cutest_error
+
+      return f[1], c
+    end
+
+    function NLPModels.objcons!(nlp :: CUTEstModel, x :: AbstractVector{$typ}, c :: AbstractVector{$typ})
+      m = nlp.meta.ncon
+      if m > 0
+        cc = zeros($typ, m)
+        f, _ = objcons!(nlp, Vector(x), cc)
+        c .= cc
+        return f, c
+      else
+        return objcons!(nlp, Vector(x), zeros($typ, 0))
+      end
+    end
+
+    function NLPModels.objgrad!(nlp :: CUTEstModel, x :: Vector{$typ}, g :: Vector{$typ})
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      f = $ctyp[0]
+      io_err = Cint[0]
+      get_grad = 1
+      if ncon > 0
+        ccall(dlsym($cutest_lib, "cutest_cofg_"), Nothing,
+            (Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}, Ref{Int32}),
+                 io_err,       nvar,         x,         f,         g,   get_grad)
+      else
+        ccall(dlsym($cutest_lib, "cutest_uofg_"), Nothing,
+            (Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}, Ref{Int32}),
+                 io_err,       nvar,         x,         f,         g,   get_grad)
+      end
+      nlp.counters.neval_obj += 1
+      nlp.counters.neval_grad += 1
+      @cutest_error
+
+      return f[1], g
+    end
+
+    function NLPModels.objgrad!(nlp :: CUTEstModel, x :: AbstractVector{$typ}, g :: Vector{$typ})
+      objgrad!(nlp, Vector{$typ}(x), g)
+    end
   end
-  nlp.counters.neval_obj += 1
-  nlp.counters.neval_grad += 1
-  @cutest_error
 
-  return f[1], g
-end
-
-function NLPModels.objgrad!(nlp :: CUTEstModel, x :: AbstractVector, g :: Array{Float64,1})
-  objgrad!(nlp, Vector{Float64}(x), g)
 end
 
 function NLPModels.objgrad!(nlp :: CUTEstModel, x :: AbstractVector, g :: AbstractVector)
-  gc = zeros(nlp.meta.nvar)
-  f, _ = objgrad!(nlp, Vector{Float64}(x), gc)
+  gc = Vector{eltype(x)}(undef, nlp.meta.nvar)
+  f, _ = objgrad!(nlp, Vector(x), gc)
   g .= gc
   return f, g
 end
@@ -97,7 +99,7 @@ end
 
 @doc (@doc NLPModels.grad)
 function NLPModels.grad(nlp :: CUTEstModel, x :: AbstractVector)
-  g = Array{Float64}(undef, nlp.meta.nvar)
+  g = Vector{eltype(x)}(undef, nlp.meta.nvar)
   return grad!(nlp, x, g)
 end
 
@@ -124,30 +126,39 @@ Usage:
   - jcol: [OUT] Array{Int32, 1}
   - jval: [OUT] Array{Float64, 1}
 """
-function cons_coord(nlp :: CUTEstModel, x :: Array{Float64,1})
-  nvar = nlp.meta.nvar;
-  ncon = nlp.meta.ncon;
-  nnzj = nlp.meta.nnzj;
-  io_err = Cint[0];
-  c = Array{Float64}(undef, ncon);
-  jsize = nlp.meta.nnzj
-  get_j = 1
-  jval = Array{Float64}(undef, jsize);
-  jrow = Array{Int32}(undef, jsize);
-  jcol = Array{Int32}(undef, jsize);
+cons_coord
 
-  ccall(dlsym(cutest_lib, :cutest_ccfsg_), Nothing,
-              (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Int32}, Ptr{Int32}, Ref{Int32}),
-               io_err,     nvar,       ncon,       x,            c,            nnzj,       jsize,      jval,         jcol,       jrow,       get_j);
-  @cutest_error
-  nlp.counters.neval_cons += 1
-  nlp.counters.neval_jac += 1
-  return c, Int.(jrow), Int.(jcol), jval
+for (typ, cutest_lib) in ((Float64, :cutest_lib_double),
+                          (Float32, :cutest_lib_single))
+
+  @eval begin
+    function cons_coord(nlp :: CUTEstModel, x :: Vector{$typ})
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      nnzj = nlp.meta.nnzj
+      io_err = Cint[0]
+      c = Vector{$typ}(undef, ncon)
+      jsize = nlp.meta.nnzj
+      get_j = 1
+      jval = Vector{$typ}(undef, jsize)
+      jrow = Array{Int32}(undef, jsize)
+      jcol = Array{Int32}(undef, jsize)
+
+      ccall(dlsym(eval($cutest_lib), :cutest_ccfsg_), Nothing,
+                  (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{Int32}, Ptr{Int32}, Ref{Int32}),
+                   io_err,     nvar,       ncon,       x,         c,         nnzj,       jsize,      jval,      jcol,       jrow,       get_j)
+      @cutest_error
+      nlp.counters.neval_cons += 1
+      nlp.counters.neval_jac += 1
+      return c, Int.(jrow), Int.(jcol), jval
+    end
+  end
 end
 
 function cons_coord(nlp :: CUTEstModel, x :: AbstractVector)
-  cons_coord(nlp, Vector{Float64}(x))
+  cons_coord(nlp, Vector(x))
 end
+
 
 """
     consjac(nlp, x)
@@ -164,13 +175,13 @@ Usage:
   - J:    [OUT] Base.SparseMatrix.SparseMatrixCSC{Float64,Int32}
 """
 function consjac(nlp :: CUTEstModel, x :: AbstractVector)
-  c, jrow, jcol, jval = cons_coord(nlp, x);
+  c, jrow, jcol, jval = cons_coord(nlp, x)
   return c, sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
 end
 
 @doc (@doc NLPModels.cons)
 function NLPModels.cons(nlp :: CUTEstModel, x :: AbstractVector)
-  c = Array{Float64}(undef, nlp.meta.ncon)
+  c = Vector{eltype(x)}(undef, nlp.meta.ncon)
   cons!(nlp, x, c)
 end
 
@@ -178,7 +189,7 @@ end
 function NLPModels.cons!(nlp :: CUTEstModel, x :: AbstractVector, c :: AbstractVector)
   objcons!(nlp, x, c)
   nlp.counters.neval_obj -= 1  # does not really count as a objective eval
-  return c;
+  return c
 end
 
 @doc (@doc NLPModels.jac_coord!)
@@ -201,158 +212,173 @@ function NLPModels.jprod(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractV
   jprod!(nlp, x, v, jv)
 end
 
-@doc (@doc NLPModels.jprod!)
-function NLPModels.jprod!(nlp :: CUTEstModel, x :: Array{Float64,1}, v :: Array{Float64,1}, jv :: Array{Float64,1})
-  nvar = nlp.meta.nvar
-  ncon = nlp.meta.ncon
-  got_j = 0
-  jtrans = 0
-  io_err = Cint[0];
-  ccall(dlsym(cutest_lib, :cutest_cjprod_), Nothing,
-              (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ref{Int32}, Ptr{Float64}, Ref{Int32}),
-               io_err,     nvar,       ncon,       got_j,      jtrans,    x,            v,             nvar,      jv,            ncon);
-  @cutest_error
-  nlp.counters.neval_jprod += 1
-  return jv
+for (typ, cutest_lib) in ((Float64, :cutest_lib_double),
+                          (Float32, :cutest_lib_single))
+
+  @eval begin
+    function NLPModels.jprod!(nlp :: CUTEstModel, x :: Vector{$typ}, v :: Vector{$typ}, jv :: Vector{$typ})
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      got_j = 0
+      jtrans = 0
+      io_err = Cint[0]
+      ccall(dlsym(eval($cutest_lib), :cutest_cjprod_), Nothing,
+                  (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ref{Int32}, Ptr{$typ}, Ref{Int32}),
+                   io_err,     nvar,       ncon,       got_j,      jtrans,     x,         v,         nvar,       jv,        ncon)
+      @cutest_error
+      nlp.counters.neval_jprod += 1
+      return jv
+    end
+
+    function NLPModels.jtprod!(nlp :: CUTEstModel, x :: Vector{$typ}, v :: Vector{$typ}, jtv :: Vector{$typ})
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      got_j = 0
+      jtrans = 1
+      io_err = Cint[0]
+      ccall(dlsym(eval($cutest_lib), :cutest_cjprod_), Nothing,
+                  (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ref{Int32}, Ptr{$typ}, Ref{Int32}),
+                   io_err,     nvar,       ncon,       got_j,      jtrans,     x,         v,         ncon,       jtv,       nvar)
+      @cutest_error
+      nlp.counters.neval_jtprod += 1
+      return jtv
+    end
+  end
+
 end
 
-function NLPModels.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: Array{Float64,1})
-  jprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jv)
+@doc (@doc NLPModels.jprod!)
+function NLPModels.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: Vector)
+  jprod!(nlp, Vector{eltype(jv)}(x), Vector{eltype(jv)}(v), jv)
 end
 
 function NLPModels.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: AbstractVector)
-  jvc = zeros(nlp.meta.ncon)
-  jprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jvc)
+  jvc = zeros(eltype(x), nlp.meta.ncon)
+  jprod!(nlp, Vector(x), Vector{eltype(x)}(v), jvc)
   jv .= jvc
 end
 
 @doc (@doc NLPModels.jtprod)
 function NLPModels.jtprod(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector)
-  jtv = zeros(nlp.meta.nvar)
+  jtv = zeros(eltype(x), nlp.meta.nvar)
   jtprod!(nlp, x, v, jtv)
 end
 
-@doc (@doc NLPModels.jtprod!)
-function NLPModels.jtprod!(nlp :: CUTEstModel, x :: Array{Float64,1}, v :: Array{Float64,1}, jtv :: Array{Float64,1})
-  nvar = nlp.meta.nvar
-  ncon = nlp.meta.ncon
-  got_j = 0
-  jtrans = 1
-  io_err = Cint[0];
-  ccall(dlsym(cutest_lib, :cutest_cjprod_), Nothing,
-              (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ref{Int32}, Ptr{Float64}, Ref{Int32}),
-               io_err,     nvar,       ncon,       got_j,      jtrans,    x,            v,             ncon,      jtv,           nvar);
-  @cutest_error
-  nlp.counters.neval_jtprod += 1
-  return jtv
-end
-
-function NLPModels.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: Array{Float64,1})
-  jtprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jtv)
+function NLPModels.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: Vector)
+  jtprod!(nlp, Vector{eltype(jtv)}(x), Vector{eltype(jtv)}(v), jtv)
 end
 
 function NLPModels.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: AbstractVector)
-  jtvc = zeros(nlp.meta.nvar)
-  jtprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jtvc)
+  jtvc = zeros(eltype(x), nlp.meta.nvar)
+  jtprod!(nlp, Vector(x), Vector{eltype(x)}(v), jtvc)
   jtv .= jtvc
 end
 
-@doc (@doc NLPModels.hess_coord)
-function NLPModels.hess_coord(nlp :: CUTEstModel, x :: Array{Float64,1}; y :: Array{Float64,1}=zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  nvar = nlp.meta.nvar;
-  ncon = nlp.meta.ncon;
-  nnzh = nlp.meta.nnzh;
-  io_err = Cint[0];
-  hval = Array{Float64}(undef, nnzh);
-  hrow = Array{Int32}(undef, nnzh);
-  hcol = Array{Int32}(undef, nnzh);
-  this_nnzh = Cint[0];
+for (typ, cutest_lib) in ((Float64, :cutest_lib_double),
+                          (Float32, :cutest_lib_single))
 
-  if obj_weight == 0.0 && ncon > 0
-    ccall(dlsym(cutest_lib, :cutest_cshc_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Int32}, Ptr{Int32}),
-                 io_err,     nvar,       ncon,      x,            y,            this_nnzh,   nnzh,      hval,         hrow,       hcol);
-    @cutest_error
-    nlp.counters.neval_hess += 1
-    return (Int.(hcol), Int.(hrow), hval)
+  @eval begin
+    function NLPModels.hess_coord(nlp :: CUTEstModel, x :: Vector{$typ}; y :: Vector{$typ}=zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      nnzh = nlp.meta.nnzh
+      io_err = Cint[0]
+      hval = Vector{$typ}(undef, nnzh)
+      hrow = Array{Int32}(undef, nnzh)
+      hcol = Array{Int32}(undef, nnzh)
+      this_nnzh = Cint[0]
+
+      if obj_weight == 0.0 && ncon > 0
+        ccall(dlsym(eval($cutest_lib), :cutest_cshc_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{Int32}, Ptr{Int32}),
+                     io_err,     nvar,       ncon,       x,         y,         this_nnzh,  nnzh,       hval,      hrow,       hcol)
+        @cutest_error
+        nlp.counters.neval_hess += 1
+        return (Int.(hcol), Int.(hrow), hval)
+      end
+
+      if ncon > 0
+        # σ H₀ + ∑ᵢ yᵢ Hᵢ = σ (H₀ + ∑ᵢ (yᵢ/σ) Hᵢ)
+        obj_weight != 1 && (y /= obj_weight)
+
+        ccall(dlsym(eval($cutest_lib), :cutest_csh_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{Int32}, Ptr{Int32}),
+                     io_err,     nvar,       ncon,       x,         y,         this_nnzh,  nnzh,       hval,      hrow,       hcol)
+      else
+        ccall(dlsym(eval($cutest_lib), :cutest_ush_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{Int32}, Ref{Int32}, Ptr{$typ}, Ptr{Int32}, Ptr{Int32}),
+                     io_err,     nvar,       x,         this_nnzh,  nnzh,       hval,      hrow,       hcol)
+      end
+      @cutest_error
+
+      obj_weight != 1 && (hval[:] *= obj_weight)  # also ok if obj_weight == 0 and ncon == 0
+      nlp.counters.neval_hess += 1
+      return (Int.(hcol), Int.(hrow), hval);  # swap rows and column
+    end
+
+    @doc (@doc NLPModels.hess_coord)
+    function NLPModels.hess_coord(nlp :: CUTEstModel, x :: AbstractVector{$typ}; y :: AbstractVector=zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      hess_coord(nlp, Vector(x), y=Vector{$typ}(y), obj_weight=obj_weight)
+    end
+
+    @doc (@doc NLPModels.hess)
+    function NLPModels.hess(nlp :: CUTEstModel, x :: AbstractVector{$typ}; y :: AbstractVector = zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      (hrow, hcol, hval) = hess_coord(nlp, x, y=y, obj_weight=obj_weight)
+      return sparse(hrow, hcol, hval, nlp.meta.nvar, nlp.meta.nvar)
+    end
+
+    @doc (@doc NLPModels.hprod)
+    function NLPModels.hprod(nlp :: CUTEstModel, x :: AbstractVector{$typ}, v :: AbstractVector; y :: AbstractVector = zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      hv = Vector{$typ}(undef, nlp.meta.nvar)
+      return hprod!(nlp, x, v, hv, y=y, obj_weight=obj_weight)
+    end
+
+    function NLPModels.hprod!(nlp :: CUTEstModel, x :: Vector{$typ}, v :: Vector{$typ}, hv :: Vector{$typ}; y :: Vector{$typ}=zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      nvar = nlp.meta.nvar
+      ncon = nlp.meta.ncon
+      io_err = Cint[0]
+      goth = Cint[0]
+
+      if obj_weight == 0 && ncon > 0
+        ccall(dlsym(eval($cutest_lib), :cutest_chcprod_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}),
+                     io_err,     nvar,       ncon,       goth,       x,         y,         v,         hv)
+        @cutest_error
+        nlp.counters.neval_hprod += 1
+        return hv
+      end
+
+      if ncon > 0
+        # σ H₀ + ∑ᵢ yᵢ Hᵢ = σ (H₀ + ∑ᵢ (yᵢ/σ) Hᵢ)
+        obj_weight != 1 && (y /= obj_weight)
+
+        ccall(dlsym(eval($cutest_lib), :cutest_chprod_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}),
+                     io_err,     nvar,       ncon,       goth,       x,         y,         v,         hv)
+      else
+        ccall(dlsym(eval($cutest_lib), :cutest_uhprod_), Nothing,
+                    (Ptr{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}),
+                     io_err,     nvar,       goth,       x,         v,         hv)
+      end
+      @cutest_error
+
+      obj_weight != 1 && (hv[:] *= obj_weight)  # also ok if obj_weight == 0 and ncon == 0
+      nlp.counters.neval_hprod += 1
+      return hv
+    end
+
+    function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector{$typ}, v :: AbstractVector{$typ}, hv :: Vector{$typ}; y :: AbstractVector=zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      hprod!(nlp, Vector(x), Vector{$typ}(v), hv, y=Vector{$typ}(y), obj_weight=obj_weight)
+    end
+
+    function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector{$typ}, v :: AbstractVector{$typ}, hv :: AbstractVector{$typ}; y :: AbstractVector=zeros($typ, nlp.meta.ncon), obj_weight :: $typ=$typ(1))
+      hvc = Vector{$typ}(undef, nlp.meta.nvar)
+      hprod!(nlp, Vector(x), Vector(v), hvc, y=Vector(y), obj_weight=obj_weight)
+      hv .= hvc
+    end
   end
 
-  if ncon > 0
-    # σ H₀ + ∑ᵢ yᵢ Hᵢ = σ (H₀ + ∑ᵢ (yᵢ/σ) Hᵢ)
-    obj_weight != 1.0 && (y /= obj_weight)
-
-    ccall(dlsym(cutest_lib, :cutest_csh_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Int32}, Ptr{Int32}),
-                 io_err,     nvar,       ncon,       x,            y,            this_nnzh,  nnzh,       hval,         hrow,       hcol);
-  else
-    ccall(dlsym(cutest_lib, :cutest_ush_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Int32}, Ref{Int32}, Ptr{Float64}, Ptr{Int32}, Ptr{Int32}),
-                 io_err,     nvar,       x,            this_nnzh,  nnzh,       hval,         hrow,       hcol);
-  end
-  @cutest_error
-
-  obj_weight != 1.0 && (hval[:] *= obj_weight)  # also ok if obj_weight == 0 and ncon == 0
-  nlp.counters.neval_hess += 1
-  return (Int.(hcol), Int.(hrow), hval);  # swap rows and column
-end
-
-function NLPModels.hess_coord(nlp :: CUTEstModel, x :: AbstractVector; y :: AbstractVector=zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  hess_coord(nlp, Vector{Float64}(x), y=Vector{Float64}(y), obj_weight=obj_weight)
-end
-
-@doc (@doc NLPModels.hess)
-function NLPModels.hess(nlp :: CUTEstModel, x :: AbstractVector; y :: AbstractVector = zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  (hrow, hcol, hval) = hess_coord(nlp, x, y=y, obj_weight=obj_weight)
-  return sparse(hrow, hcol, hval, nlp.meta.nvar, nlp.meta.nvar)
-end
-
-@doc (@doc NLPModels.hprod)
-function NLPModels.hprod(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector; y :: AbstractVector = zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  hv = Array{Float64}(undef, nlp.meta.nvar);
-  return hprod!(nlp, x, v, hv, y=y, obj_weight=obj_weight)
 end
 
 @doc (@doc NLPModels.hprod!)
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: Array{Float64,1}, v :: Array{Float64,1}, hv :: Array{Float64,1}; y :: Array{Float64,1}=zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  nvar = nlp.meta.nvar;
-  ncon = nlp.meta.ncon;
-  io_err = Cint[0];
-  goth = Cint[0];
-
-  if obj_weight == 0.0 && ncon > 0
-    ccall(dlsym(cutest_lib, :cutest_chcprod_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
-                 io_err,     nvar,       ncon,       goth,       x,            y,            v,            hv);
-    @cutest_error
-    nlp.counters.neval_hprod += 1
-    return hv
-  end
-
-  if ncon > 0
-    # σ H₀ + ∑ᵢ yᵢ Hᵢ = σ (H₀ + ∑ᵢ (yᵢ/σ) Hᵢ)
-    obj_weight != 1.0 && (y /= obj_weight)
-
-    ccall(dlsym(cutest_lib, :cutest_chprod_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
-                 io_err,     nvar,       ncon,       goth,       x,            y,            v,            hv);
-  else
-    ccall(dlsym(cutest_lib, :cutest_uhprod_), Nothing,
-                (Ptr{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
-                 io_err,     nvar,       goth,       x,            v,            hv);
-  end
-  @cutest_error
-
-  obj_weight != 1.0 && (hv[:] *= obj_weight)  # also ok if obj_weight == 0 and ncon == 0
-  nlp.counters.neval_hprod += 1
-  return hv
-end
-
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, hv :: Array{Float64,1}; y :: AbstractVector=zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  hprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), hv, y=Vector{Float64}(y), obj_weight=obj_weight)
-end
-
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; y :: AbstractVector=zeros(nlp.meta.ncon), obj_weight :: Float64=1.0)
-  hvc = zeros(nlp.meta.nvar)
-  hprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), hvc, y=Vector{Float64}(y), obj_weight=obj_weight)
-  hv .= hvc
-end
+hprod!

--- a/src/precision_dependent.jl
+++ b/src/precision_dependent.jl
@@ -1,0 +1,447 @@
+for (typ, cutest_lib) in ((Cdouble, :cutest_lib_double),
+                          (Cfloat, :cutest_lib_single))
+
+  @eval begin
+
+    function usetup(io_err::Vector{Cint}, input::Vector{Cint}, out::Vector{Cint},
+        io_buffer::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        x_l::Vector{$typ}, x_u::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_usetup_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{$typ}),
+        io_err, input, out, io_buffer, n, x, x_l, x_u)
+    end
+
+    function csetup(io_err::Vector{Cint}, input::Vector{Cint}, out::Vector{Cint},
+        io_buffer::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, x_l::Vector{$typ}, x_u::Vector{$typ},
+        y::Vector{$typ}, c_l::Vector{$typ}, c_u::Vector{$typ},
+        equatn::Vector{Cint}, linear::Vector{Cint}, e_order::Vector{Cint},
+        l_order::Vector{Cint}, v_order::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_csetup_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ},
+        Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        io_err, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn,
+        linear, e_order, l_order, v_order)
+    end
+
+    function ufn(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        f::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_ufn_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}),
+        io_err, n, x, f)
+    end
+
+    function ugr(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        g::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_ugr_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}),
+        io_err, n, x, g)
+    end
+
+    function uofg(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        f::Vector{$typ}, g::Vector{$typ}, grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_uofg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}),
+        io_err, n, x, f, g, grad)
+    end
+
+    function udh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        lh1::Vector{Cint}, h::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_udh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{$typ}),
+        io_err, n, x, lh1, h)
+    end
+
+    function ush(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        nnzh::Vector{Cint}, lh::Vector{Cint}, h_val::Vector{$typ},
+        h_row::Vector{Cint}, h_col::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ush_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, x, nnzh, lh, h_val, h_row, h_col)
+    end
+
+    function ueh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        ne::Vector{Cint}, lhe_ptr::Vector{Cint}, he_row_ptr::Vector{Cint},
+        he_val_ptr::Vector{Cint}, lhe_row::Vector{Cint},
+        he_row::Vector{Cint}, lhe_val::Vector{Cint},
+        he_val::Vector{$typ}, byrows::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ueh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}),
+        io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
+        lhe_val, he_val, byrows)
+    end
+
+    function ugrdh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        g::Vector{$typ}, lh1::Vector{Cint}, h::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_ugrdh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}, Ptr{Cint},
+        Ptr{$typ}),
+        io_err, n, x, g, lh1, h)
+    end
+
+    function ugrsh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        g::Vector{$typ}, nnzh::Vector{Cint}, lh::Vector{Cint},
+        h_val::Vector{$typ}, h_row::Vector{Cint}, h_col::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ugrsh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}, Ptr{Cint},
+        Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
+    end
+
+    function ugreh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        g::Vector{$typ}, ne::Vector{Cint}, lhe_ptr::Vector{Cint},
+        he_row_ptr::Vector{Cint}, he_val_ptr::Vector{Cint},
+        lhe_row::Vector{Cint}, he_row::Vector{Cint}, lhe_val::Vector{Cint},
+        he_val::Vector{$typ}, byrows::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ugreh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}, Ptr{Cint},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{Cint}),
+        io_err, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
+        lhe_val, he_val, byrows)
+    end
+
+    function uhprod(io_err::Vector{Cint}, n::Vector{Cint}, goth::Vector{Cint},
+        x::Vector{$typ}, vector::Vector{$typ},
+        result::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_uhprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{$typ}),
+        io_err, n, goth, x, vector, result)
+    end
+
+    function ushprod(io_err::Vector{Cint}, n::Vector{Cint}, goth::Vector{Cint},
+        x::Vector{$typ}, nnz_vector::Vector{Cint},
+        index_nz_vector::Vector{Cint}, vector::Vector{$typ},
+        nnz_result::Vector{Cint}, index_nz_result::Vector{Cint},
+        result::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_ushprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}),
+        io_err, n, goth, x, nnz_vector, index_nz_vector, vector, nnz_result,
+        index_nz_result, result)
+    end
+
+    function ubandh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        semibandwidth::Vector{Cint}, h_band::Array{$typ, 2},
+        lbandh::Vector{Cint}, max_semibandwidth::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ubandh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}),
+        io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
+    end
+
+    function cfn(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, f::Vector{$typ}, c::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_cfn_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{$typ}),
+        io_err, n, m, x, f, c)
+    end
+
+    function cofg(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        f::Vector{$typ}, g::Vector{$typ}, grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cofg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}),
+        io_err, n, x, f, g, grad)
+    end
+
+    function cofsg(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        f::Vector{$typ}, nnzg::Vector{Cint}, lg::Vector{Cint},
+        g_val::Vector{$typ}, g_var::Vector{Cint}, grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cofsg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}, Ptr{Cint},
+        Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
+    end
+
+    function ccfg(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, c::Vector{$typ}, jtrans::Vector{Cint},
+        lcjac1::Vector{Cint}, lcjac2::Vector{Cint}, cjac::Array{$typ, 2},
+        grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ccfg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}),
+        io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+    end
+
+    function clfg(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, f::Vector{$typ},
+        g::Vector{$typ}, grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_clfg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{$typ}, Ptr{$typ}, Ptr{Cint}),
+        io_err, n, m, x, y, f, g, grad)
+    end
+
+    function cgr(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, grlagf::Vector{Cint},
+        g::Vector{$typ}, jtrans::Vector{Cint}, lj1::Vector{Cint},
+        lj2::Vector{Cint}, j_val::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_cgr_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}),
+        io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
+    end
+
+    function csgr(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, grlagf::Vector{Cint},
+        nnzj::Vector{Cint}, lj::Vector{Cint}, j_val::Vector{$typ},
+        j_var::Vector{Cint}, j_fun::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_csgr_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
+    end
+
+    function ccfsg(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, c::Vector{$typ}, nnzj::Vector{Cint},
+        lj::Vector{Cint}, j_val::Vector{$typ}, j_var::Vector{Cint},
+        j_fun::Vector{Cint}, grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ccfsg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
+    end
+
+    function ccifg(io_err::Vector{Cint}, n::Vector{Cint}, icon::Vector{Cint},
+        x::Vector{$typ}, ci::Vector{$typ}, gci::Vector{$typ},
+        grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ccifg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{$typ}, Ptr{Cint}),
+        io_err, n, icon, x, ci, gci, grad)
+    end
+
+    function ccifsg(io_err::Vector{Cint}, n::Vector{Cint}, icon::Vector{Cint},
+        x::Vector{$typ}, ci::Vector{$typ}, nnzgci::Vector{Cint},
+        lgci::Vector{Cint}, gci_val::Vector{$typ}, gci_var::Vector{Cint},
+        grad::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ccifsg_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
+    end
+
+    function cgrdh(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, grlagf::Vector{Cint},
+        g::Vector{$typ}, jtrans::Vector{Cint}, lj1::Vector{Cint},
+        lj2::Vector{Cint}, j_val::Array{$typ, 2}, lh1::Vector{Cint},
+        h_val::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_cgrdh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{Cint}, Ptr{$typ}),
+        io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
+    end
+
+    function cdh(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, lh1::Vector{Cint},
+        h_val::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_cdh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{$typ}),
+        io_err, n, m, x, y, lh1, h_val)
+    end
+
+    function cdhc(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, lh1::Vector{Cint},
+        h_val::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_cdhc_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{$typ}),
+        io_err, n, m, x, y, lh1, h_val)
+    end
+
+    function csh(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, nnzh::Vector{Cint},
+        lh::Vector{Cint}, h_val::Vector{$typ}, h_row::Vector{Cint},
+        h_col::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_csh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
+    end
+
+    function cshc(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, nnzh::Vector{Cint},
+        lh::Vector{Cint}, h_val::Vector{$typ}, h_row::Vector{Cint},
+        h_col::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cshc_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
+    end
+
+    function ceh(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, ne::Vector{Cint},
+        lhe_ptr::Vector{Cint}, he_row_ptr::Vector{Cint},
+        he_val_ptr::Vector{Cint}, lhe_row::Vector{Cint},
+        he_row::Vector{Cint}, lhe_val::Vector{Cint},
+        he_val::Vector{$typ}, byrows::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_ceh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{Cint}, Ptr{$typ}, Ptr{Cint}),
+        io_err, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row,
+        he_row, lhe_val, he_val, byrows)
+    end
+
+    function cidh(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        iprob::Vector{Cint}, lh1::Vector{Cint}, h::Array{$typ, 2})
+      ccall(dlsym(eval($cutest_lib), "cutest_cidh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}),
+        io_err, n, x, iprob, lh1, h)
+    end
+
+    function cish(io_err::Vector{Cint}, n::Vector{Cint}, x::Vector{$typ},
+        iprob::Vector{Cint}, nnzh::Vector{Cint}, lh::Vector{Cint},
+        h_val::Vector{$typ}, h_row::Vector{Cint}, h_col::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cish_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
+    end
+
+    function csgrsh(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, grlagf::Vector{Cint},
+        nnzj::Vector{Cint}, lj::Vector{Cint}, j_val::Vector{$typ},
+        j_var::Vector{Cint}, j_fun::Vector{Cint}, nnzh::Vector{Cint},
+        lh::Vector{Cint}, h_val::Vector{$typ}, h_row::Vector{Cint},
+        h_col::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_csgrsh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint},
+        Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh,
+        h_val, h_row, h_col)
+    end
+
+    function csgreh(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        x::Vector{$typ}, y::Vector{$typ}, grlagf::Vector{Cint},
+        nnzj::Vector{Cint}, lj::Vector{Cint}, j_val::Vector{$typ},
+        j_var::Vector{Cint}, j_fun::Vector{Cint}, ne::Vector{Cint},
+        lhe_ptr::Vector{Cint}, he_row_ptr::Vector{Cint},
+        he_val_ptr::Vector{Cint}, lhe_row::Vector{Cint},
+        he_row::Vector{Cint}, lhe_val::Vector{Cint},
+        he_val::Vector{$typ}, byrows::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_csgreh_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint},
+        Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{Cint}, Ptr{$typ}, Ptr{Cint}),
+        io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne,
+        lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val,
+        byrows)
+    end
+
+    function chprod(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        goth::Vector{Cint}, x::Vector{$typ}, y::Vector{$typ},
+        vector::Vector{$typ}, result::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_chprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{$typ}, Ptr{$typ}),
+        io_err, n, m, goth, x, y, vector, result)
+    end
+
+    function cshprod(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        goth::Vector{Cint}, x::Vector{$typ}, y::Vector{$typ},
+        nnz_vector::Vector{Cint}, index_nz_vector::Vector{Cint},
+        vector::Vector{$typ}, nnz_result::Vector{Cint},
+        index_nz_result::Vector{Cint}, result::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_cshprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint},
+        Ptr{Cint}, Ptr{$typ}),
+        io_err, n, m, goth, x, y, nnz_vector, index_nz_vector, vector,
+        nnz_result, index_nz_result, result)
+    end
+
+    function chcprod(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        goth::Vector{Cint}, x::Vector{$typ}, y::Vector{$typ},
+        vector::Vector{$typ}, result::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_chcprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{$typ}, Ptr{$typ}),
+        io_err, n, m, goth, x, y, vector, result)
+    end
+
+    function cshcprod(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        goth::Vector{Cint}, x::Vector{$typ}, y::Vector{$typ},
+        nnz_vector::Vector{Cint}, index_nz_vector::Vector{Cint},
+        vector::Vector{$typ}, nnz_result::Vector{Cint},
+        index_nz_result::Vector{Cint}, result::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_cshcprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint},
+        Ptr{Cint}, Ptr{$typ}),
+        io_err, n, m, goth, x, y, nnz_vector, index_nz_vector, vector,
+        nnz_result, index_nz_result, result)
+    end
+
+    function cjprod(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        gotj::Vector{Cint}, jtrans::Vector{Cint}, x::Vector{$typ},
+        vector::Vector{$typ}, lvector::Vector{Cint},
+        result::Vector{$typ}, lresult::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cjprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}),
+        io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
+    end
+
+    function csjprod(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        gotj::Vector{Cint}, jtrans::Vector{Cint}, x::Vector{$typ},
+        nnz_vector::Vector{Cint}, index_nz_vector::Vector{Cint},
+        vector::Vector{$typ}, lvector::Vector{Cint},
+        nnz_result::Vector{Cint}, index_nz_result::Vector{Cint},
+        result::Vector{$typ}, lresult::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_csjprod_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+        Ptr{$typ}, Ptr{Cint}),
+        io_err, n, m, gotj, jtrans, x, nnz_vector, index_nz_vector, vector,
+        lvector, nnz_result, index_nz_result, result, lresult)
+    end
+
+    function cchprods(io_err::Vector{Cint}, n::Vector{Cint}, m::Vector{Cint},
+        goth::Vector{Cint}, x::Vector{$typ}, vector::Vector{$typ},
+        lchp::Vector{Cint}, chp_val::Vector{$typ}, chp_ind::Vector{Cint},
+        chp_ptr::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cchprods_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ},
+        Ptr{$typ}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint}),
+        io_err, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
+    end
+
+    function cifn(io_err::Vector{Cint}, n::Vector{Cint}, iprob::Vector{Cint},
+        x::Vector{$typ}, f::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_cifn_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}),
+        io_err, n, iprob, x, f)
+    end
+
+    function cisgr(io_err::Vector{Cint}, n::Vector{Cint}, iprod::Vector{Cint},
+        x::Vector{$typ}, nnzg::Vector{Cint}, lg::Vector{Cint},
+        g_val::Vector{$typ}, g_var::Vector{Cint})
+      ccall(dlsym(eval($cutest_lib), "cutest_cisgr_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{Cint}, Ptr{Cint},
+         Ptr{$typ}, Ptr{Cint}),
+        io_err, n, iprod, x, nnzg, lg, g_val, g_var)
+    end
+
+    function cigr(io_err::Vector{Cint}, n::Vector{Cint}, iprob::Vector{Cint},
+        x::Vector{$typ}, g_val::Vector{$typ})
+      ccall(dlsym(eval($cutest_lib), "cutest_cigr_"), Nothing,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{$typ}, Ptr{$typ}),
+        io_err, n, iprob, x, g_val)
+    end
+
+  end
+
+end


### PR DESCRIPTION
These are preliminary changes to support calling CUTEst in single precision. I haven't yet added single-precision tests. I see test failures locally that are probably due to an updated SIF collection (see #176).

The changes look a bit messy because I took the docstrings out of the `@eval` blocks.