### PR TITLE
allow command that does not decode a problem

### DIFF
--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -98,17 +98,20 @@ function sifdecoder(name :: String, args...; verbose :: Bool=false,
   outlog = tempname()
   errlog = tempname()
   cd(ENV["cutest-problems"]) do
+    run(`rm -f ELFUN.[fo] EXTER.[fo] GROUP.[fo] RANGE.[fo] OUTSDIF.d AUTOMAT.d`)
     run(pipeline(ignorestatus(`$sifdecoderbin $args $name`), stdout=outlog, stderr=errlog))
     print(read(errlog, String))
     verbose && println(read(outlog, String))
 
-    run(`gfortran -c -fPIC ELFUN.f EXTER.f GROUP.f RANGE.f`)
-    run(`$linker $sh_flags -o $libname.$(Libdl.dlext) ELFUN.o EXTER.o GROUP.o RANGE.o $libpath $libgfortran`)
-    run(`mv OUTSDIF.d $outsdif`)
-    run(`mv AUTOMAT.d $automat`)
-    run(`rm ELFUN.f EXTER.f GROUP.f RANGE.f ELFUN.o EXTER.o GROUP.o RANGE.o`)
-    global cutest_lib = Libdl.dlopen(libname,
-      Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
+    if isfile("ELFUN.f")
+      run(`gfortran -c -fPIC ELFUN.f EXTER.f GROUP.f RANGE.f`)
+      run(`$linker $sh_flags -o $libname.$(Libdl.dlext) ELFUN.o EXTER.o GROUP.o RANGE.o $libpath $libgfortran`)
+      run(`mv OUTSDIF.d $outsdif`)
+      run(`mv AUTOMAT.d $automat`)
+      run(`rm ELFUN.f EXTER.f GROUP.f RANGE.f ELFUN.o EXTER.o GROUP.o RANGE.o`)
+      global cutest_lib = Libdl.dlopen(libname,
+        Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
+    end
   end
 end
 


### PR DESCRIPTION
The command `sifdecoder("LUBRIFC", "-show")` currently fails because it does not decode a problem, but we still try to compile `ELFUN.f`, etc. This change checks that a Fortran file is produced before trying to compile.