### PR TITLE
Limit version and prepare for release 0.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 jobs:
   include:
     - stage: Documentation
-      julia: 1.1
+      julia: 1.3
       os: linux
       script:
         - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(path=pwd()))'
@@ -41,4 +41,6 @@ jobs:
       after_success: skip
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("CUTEst")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(process_folder())'
+  - julia -e 'if Sys.islinux() && string(VERSION)[1:3] == "1.3"
+      using Pkg; cd(Pkg.dir("CUTEst")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(process_folder())
+    end'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CUTEst"
 uuid = "1b53aba6-35b6-5f92-a507-53c67d53f819"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
@@ -13,10 +13,10 @@ NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Combinatorics = "≥ 0.2.1"
-Homebrew = "≥ 0.4.0"
-JSON = "≥ 0.8.0"
-Krylov = "≥ 0.2.0"
+Combinatorics = "1.0"
+Homebrew = "0.4, 0.5, 0.6, 0.7"
+JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
+Krylov = "0.2, 0.3"
 NLPModels = "0.8.2, 0.9"
 julia = "^1.0.0"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 
 [compat]
-Documenter = "~0.21"
-NLPModels = "~0.8"
+Documenter = "~0.24"
+Krylov = "0.3.1"
+NLPModels = "0.9.1"

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -69,9 +69,6 @@ You can also use a
 [LinearOperator](https://github.com/JuliaSmoothOptimizers/LinearOperators.jl),
 
 ```@example ex1
-using LinearOperators
-n = nlp.meta.nvar
-
 H = hess_op(nlp, nlp.meta.x0)
 H * v
 ```


### PR DESCRIPTION
This is being compared against a branch `release-0.6`, with cherry-picked commits since `0.6.2`.