### PR TITLE
package SIF collection as artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[sifcollection]
+git-tree-sha1 = "a7ea0d0aaf29a39ca0fe75588fc077cdd5b5ed54"
+
+    [[sifcollection.download]]
+    url = "https://bitbucket.org/optrove/sif/get/99c5b38e7d03.tar.gz"
+    sha256 = "33b29e46288c6f019f4ee58e0df6b2797bc2642419b2c181edc574c8db8f6f34"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test, CUTEst, NLPModels, LinearAlgebra, SparseArrays, Random, Printf
 
-fetch_sif_problems()
+set_mastsif()
+@test ispath(ENV["MASTSIF"])
+@test isfile(joinpath(ENV["MASTSIF"], "CYCLOOCT.SIF"))
 
 # :hs10 removed from the tests because of
 # https://github.com/JuliaSmoothOptimizers/CUTEst.jl/issues/113


### PR DESCRIPTION
Use Julia 1.3's artifact feature to download and install the SIF collection once and for all. According to the docs, the artifact will be shared by several installations of CUTEst.jl (say, in several environments), and so will be downloaded only once.