### PR TITLE
Use NLPModelsCore and TestUtils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - name: clone-core
+        run: julia -e 'using Pkg; pkg"activate ."; pkg"dev https://github.com/JuliaSmoothOptimizers/NLPModelsCore.jl"'
+      - name: clone-testutils
+        run: julia -e 'using Pkg; pkg"activate ."; pkg"dev https://github.com/JuliaSmoothOptimizers/NLPModelsTestUtils.jl"'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -8,17 +8,13 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 CUTEst_jll = "2.0.4"
-Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
-Krylov = "0.2.0, 0.3.0, 0.4.0"
-NLPModels = "0.11.0, 0.12, 0.13"
 julia = "^1.3.0"
 
 [extras]

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -7,9 +7,9 @@ module CUTEst
 
 using CUTEst_jll
 using Pkg.Artifacts
-using Libdl
+using Libdl, SparseArrays
 
-using NLPModels
+using NLPModelsCore
 import Libdl.dlsym
 
 # Only one problem can be interfaced at any given time.

--- a/src/julia_interface.jl
+++ b/src/julia_interface.jl
@@ -1,13 +1,11 @@
 export cons_coord, cons_coord!, consjac
 
-using NLPModels, SparseArrays
-
-function NLPModels.objcons(nlp :: CUTEstModel, x :: AbstractVector)
+function NLPModelsCore.objcons(nlp :: CUTEstModel, x :: AbstractVector)
   c = Vector{Float64}(undef, nlp.meta.ncon)
   objcons!(nlp, Vector{Float64}(x), c)
 end
 
-function NLPModels.objcons!(nlp :: CUTEstModel, x :: Vector{Float64}, c :: Vector{Float64})
+function NLPModelsCore.objcons!(nlp :: CUTEstModel, x :: Vector{Float64}, c :: Vector{Float64})
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   io_err = Cint[0]
@@ -28,11 +26,11 @@ function NLPModels.objcons!(nlp :: CUTEstModel, x :: Vector{Float64}, c :: Vecto
   return f[1], c
 end
 
-function NLPModels.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: Vector{Float64})
+function NLPModelsCore.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: Vector{Float64})
   objcons!(nlp, Vector{Float64}(x), c)
 end
 
-function NLPModels.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: AbstractVector)
+function NLPModelsCore.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: AbstractVector)
   m = nlp.meta.ncon
   if m > 0
     cc = zeros(m)
@@ -44,12 +42,12 @@ function NLPModels.objcons!(nlp :: CUTEstModel, x :: AbstractVector, c :: Abstra
   end
 end
 
-function NLPModels.objgrad(nlp :: CUTEstModel, x :: AbstractVector)
+function NLPModelsCore.objgrad(nlp :: CUTEstModel, x :: AbstractVector)
   g = Vector{Float64}(undef, nlp.meta.nvar)
   objgrad!(nlp, Vector{Float64}(x), g)
 end
 
-function NLPModels.objgrad!(nlp :: CUTEstModel, x :: Vector{Float64}, g :: Vector{Float64})
+function NLPModelsCore.objgrad!(nlp :: CUTEstModel, x :: Vector{Float64}, g :: Vector{Float64})
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   f = Cdouble[0]
@@ -71,18 +69,18 @@ function NLPModels.objgrad!(nlp :: CUTEstModel, x :: Vector{Float64}, g :: Vecto
   return f[1], g
 end
 
-function NLPModels.objgrad!(nlp :: CUTEstModel, x :: AbstractVector, g :: Vector{Float64})
+function NLPModelsCore.objgrad!(nlp :: CUTEstModel, x :: AbstractVector, g :: Vector{Float64})
   objgrad!(nlp, Vector{Float64}(x), g)
 end
 
-function NLPModels.objgrad!(nlp :: CUTEstModel, x :: AbstractVector, g :: AbstractVector)
+function NLPModelsCore.objgrad!(nlp :: CUTEstModel, x :: AbstractVector, g :: AbstractVector)
   gc = zeros(nlp.meta.nvar)
   f, _ = objgrad!(nlp, Vector{Float64}(x), gc)
   g[1 : nlp.meta.nvar] .= gc
   return f, g
 end
 
-function NLPModels.obj(nlp :: CUTEstModel, x :: AbstractVector)
+function NLPModelsCore.obj(nlp :: CUTEstModel, x :: AbstractVector)
   f = objcons(nlp, x)[1]
   if nlp.meta.ncon > 0
     nlp.counters.neval_cons -= 1  # does not really count as a constraint eval
@@ -90,7 +88,7 @@ function NLPModels.obj(nlp :: CUTEstModel, x :: AbstractVector)
   return f
 end
 
-function NLPModels.grad!(nlp :: CUTEstModel, x :: AbstractVector, g :: AbstractVector)
+function NLPModelsCore.grad!(nlp :: CUTEstModel, x :: AbstractVector, g :: AbstractVector)
   objgrad!(nlp, x, g)
   nlp.counters.neval_obj -= 1  # does not really count as a objective eval
   return g
@@ -189,13 +187,13 @@ function consjac(nlp :: CUTEstModel, x :: AbstractVector)
   return c, sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
 end
 
-function NLPModels.cons!(nlp :: CUTEstModel, x :: AbstractVector, c :: AbstractVector)
+function NLPModelsCore.cons!(nlp :: CUTEstModel, x :: AbstractVector, c :: AbstractVector)
   objcons!(nlp, x, c)
   nlp.counters.neval_obj -= 1  # does not really count as a objective eval
   return c
 end
 
-function NLPModels.jac_structure!(nlp :: CUTEstModel, rows :: Vector{Int32}, cols :: Vector{Int32})
+function NLPModelsCore.jac_structure!(nlp :: CUTEstModel, rows :: Vector{Int32}, cols :: Vector{Int32})
   nnzj = nlp.meta.nnzj
   io_err = Cint[0]
   this_nnzj = Cint[0]
@@ -211,7 +209,7 @@ function NLPModels.jac_structure!(nlp :: CUTEstModel, rows :: Vector{Int32}, col
   return rows, cols
 end
 
-function NLPModels.jac_structure!(nlp :: CUTEstModel)
+function NLPModelsCore.jac_structure!(nlp :: CUTEstModel)
   nnzj = nlp.meta.nnzj
   io_err = Cint[0]
   this_nnzj = Cint[0]
@@ -224,7 +222,7 @@ function NLPModels.jac_structure!(nlp :: CUTEstModel)
   return nlp
 end
 
-function NLPModels.jac_structure!(nlp :: CUTEstModel, rows :: AbstractVector{<:Integer}, cols :: AbstractVector{<:Integer})
+function NLPModelsCore.jac_structure!(nlp :: CUTEstModel, rows :: AbstractVector{<:Integer}, cols :: AbstractVector{<:Integer})
   jrows = Vector{Int32}(undef, nlp.meta.nnzj)
   jcols = Vector{Int32}(undef, nlp.meta.nnzj)
   jac_structure!(nlp, jrows, jcols)
@@ -233,14 +231,14 @@ function NLPModels.jac_structure!(nlp :: CUTEstModel, rows :: AbstractVector{<:I
   return rows, cols
 end
 
-function NLPModels.jac_coord!(nlp :: CUTEstModel, x :: AbstractVector, vals :: AbstractVector)
+function NLPModelsCore.jac_coord!(nlp :: CUTEstModel, x :: AbstractVector, vals :: AbstractVector)
   c = Vector{Float64}(undef, nlp.meta.ncon)
   cons_coord!(nlp, x, c, nlp.jrows, nlp.jcols, vals)
   nlp.counters.neval_cons -= 1  # does not really count as a constraint eval
   return vals
 end
 
-function NLPModels.jprod!(nlp :: CUTEstModel, x :: Vector{Float64}, v :: Vector{Float64}, jv :: Vector{Float64})
+function NLPModelsCore.jprod!(nlp :: CUTEstModel, x :: Vector{Float64}, v :: Vector{Float64}, jv :: Vector{Float64})
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   got_j = 0
@@ -254,17 +252,17 @@ function NLPModels.jprod!(nlp :: CUTEstModel, x :: Vector{Float64}, v :: Vector{
   return jv
 end
 
-function NLPModels.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: Vector{Float64})
+function NLPModelsCore.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: Vector{Float64})
   jprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jv)
 end
 
-function NLPModels.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: AbstractVector)
+function NLPModelsCore.jprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jv :: AbstractVector)
   jvc = zeros(nlp.meta.ncon)
   jprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jvc)
   jv[1 : nlp.meta.ncon] .= jvc
 end
 
-function NLPModels.jtprod!(nlp :: CUTEstModel, x :: Vector{Float64}, v :: Vector{Float64}, jtv :: Vector{Float64})
+function NLPModelsCore.jtprod!(nlp :: CUTEstModel, x :: Vector{Float64}, v :: Vector{Float64}, jtv :: Vector{Float64})
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   got_j = 0
@@ -278,17 +276,17 @@ function NLPModels.jtprod!(nlp :: CUTEstModel, x :: Vector{Float64}, v :: Vector
   return jtv
 end
 
-function NLPModels.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: Vector{Float64})
+function NLPModelsCore.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: Vector{Float64})
   jtprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jtv)
 end
 
-function NLPModels.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: AbstractVector)
+function NLPModelsCore.jtprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, jtv :: AbstractVector)
   jtvc = zeros(nlp.meta.nvar)
   jtprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), jtvc)
   jtv[1 : nlp.meta.nvar] .= jtvc
 end
 
-function NLPModels.hess_structure!(nlp :: CUTEstModel, rows :: Vector{Int32}, cols :: Vector{Int32})
+function NLPModelsCore.hess_structure!(nlp :: CUTEstModel, rows :: Vector{Int32}, cols :: Vector{Int32})
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   nnzh = nlp.meta.nnzh
@@ -313,7 +311,7 @@ function NLPModels.hess_structure!(nlp :: CUTEstModel, rows :: Vector{Int32}, co
   return rows, cols
 end
 
-function NLPModels.hess_structure!(nlp :: CUTEstModel)
+function NLPModelsCore.hess_structure!(nlp :: CUTEstModel)
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   nnzh = nlp.meta.nnzh
@@ -335,7 +333,7 @@ function NLPModels.hess_structure!(nlp :: CUTEstModel)
   return nlp
 end
 
-function NLPModels.hess_structure!(nlp :: CUTEstModel, rows :: AbstractVector{<:Integer}, cols :: AbstractVector{<:Integer})
+function NLPModelsCore.hess_structure!(nlp :: CUTEstModel, rows :: AbstractVector{<:Integer}, cols :: AbstractVector{<:Integer})
   hrows = Vector{Int32}(undef, nlp.meta.nnzh)
   hcols = Vector{Int32}(undef, nlp.meta.nnzh)
   hess_structure!(nlp, hrows, hcols)
@@ -344,7 +342,7 @@ function NLPModels.hess_structure!(nlp :: CUTEstModel, rows :: AbstractVector{<:
   return rows, cols
 end
 
-function NLPModels.hess_coord!(nlp :: CUTEstModel, x :: Vector{Float64}, y :: Vector{Float64}, vals :: Vector{Float64}; obj_weight :: Float64=1.0)
+function NLPModelsCore.hess_coord!(nlp :: CUTEstModel, x :: Vector{Float64}, y :: Vector{Float64}, vals :: Vector{Float64}; obj_weight :: Float64=1.0)
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   nnzh = nlp.meta.nnzh
@@ -379,18 +377,18 @@ function NLPModels.hess_coord!(nlp :: CUTEstModel, x :: Vector{Float64}, y :: Ve
   return vals
 end
 
-function NLPModels.hess_coord!(nlp :: CUTEstModel, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight :: Float64=1.0)
+function NLPModelsCore.hess_coord!(nlp :: CUTEstModel, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight :: Float64=1.0)
   vals_ = Vector{Float64}(undef, nlp.meta.nnzh)
-  NLPModels.hess_coord!(nlp, Vector{Float64}(x), Vector{Float64}(y), vals_, obj_weight=obj_weight)
+  NLPModelsCore.hess_coord!(nlp, Vector{Float64}(x), Vector{Float64}(y), vals_, obj_weight=obj_weight)
   vals[1 : nlp.meta.nnzh] .= vals_
   return vals
 end
 
-function NLPModels.hess_coord!(nlp :: CUTEstModel, x :: AbstractVector, vals :: AbstractVector; obj_weight :: Float64=1.0)
+function NLPModelsCore.hess_coord!(nlp :: CUTEstModel, x :: AbstractVector, vals :: AbstractVector; obj_weight :: Float64=1.0)
   hess_coord!(nlp, x, zeros(nlp.meta.ncon), vals; obj_weight=obj_weight)
 end
 
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: Vector{Float64}, y :: Vector{Float64}, v :: Vector{Float64}, hv :: Vector{Float64}; obj_weight :: Float64=1.0)
+function NLPModelsCore.hprod!(nlp :: CUTEstModel, x :: Vector{Float64}, y :: Vector{Float64}, v :: Vector{Float64}, hv :: Vector{Float64}; obj_weight :: Float64=1.0)
   nvar = nlp.meta.nvar
   ncon = nlp.meta.ncon
   io_err = Cint[0]
@@ -423,21 +421,21 @@ function NLPModels.hprod!(nlp :: CUTEstModel, x :: Vector{Float64}, y :: Vector{
   return hv
 end
 
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: Vector{Float64}; obj_weight :: Float64=1.0)
+function NLPModelsCore.hprod!(nlp :: CUTEstModel, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: Vector{Float64}; obj_weight :: Float64=1.0)
   hprod!(nlp, Vector{Float64}(x), Vector{Float64}(y), Vector{Float64}(v), hv, obj_weight=obj_weight)
 end
 
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Float64=1.0)
+function NLPModelsCore.hprod!(nlp :: CUTEstModel, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Float64=1.0)
   hvc = zeros(nlp.meta.nvar)
   hprod!(nlp, Vector{Float64}(x), Vector{Float64}(y), Vector{Float64}(v), hvc, obj_weight=obj_weight)
   hv[1 : nlp.meta.nvar] .= hvc
 end
 
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, hv :: Vector{Float64}; obj_weight :: Float64=1.0)
+function NLPModelsCore.hprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, hv :: Vector{Float64}; obj_weight :: Float64=1.0)
   hprod!(nlp, Vector{Float64}(x), zeros(nlp.meta.ncon), Vector{Float64}(v), hv, obj_weight=obj_weight)
 end
 
-function NLPModels.hprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Float64=1.0)
+function NLPModelsCore.hprod!(nlp :: CUTEstModel, x :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Float64=1.0)
   hvc = zeros(nlp.meta.nvar)
   hprod!(nlp, Vector{Float64}(x), Vector{Float64}(v), hvc, obj_weight=obj_weight)
   hv[1 : nlp.meta.nvar] .= hvc

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -1,15 +1,13 @@
-include(joinpath(nlpmodels_path, "consistency.jl"))
-
-problems = [:brownden, :hs5, :hs6, :hs11, :hs14]
 for problem in problems
-  problem_s = string(problem)
+  @testset "Checking problem $problem" begin
+    problem_s = string(problem)
 
-  nlp_autodiff = eval(Meta.parse("$(problem)_autodiff"))()
-  nlp_cutest = CUTEstModel(uppercase(problem_s))
-  nlps = [nlp_cutest, nlp_autodiff]
+    nlp_man = eval(problem)()
+    nlp_cutest = CUTEstModel(uppercase(problem_s))
+    nlps = [nlp_cutest, nlp_man]
 
-  @printf("Checking problem %-15s%12s\t", problem_s, "")
-  consistent_nlps(nlps)
+    consistent_nlps(nlps)
 
-  finalize(nlp_cutest)
+    finalize(nlp_cutest)
+  end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, CUTEst, NLPModels, LinearAlgebra, SparseArrays, Random, Printf
+using Test, CUTEst, NLPModelsCore, NLPModelsTestUtils, LinearAlgebra, SparseArrays, Random, Printf
 
 set_mastsif()
 @test ispath(ENV["MASTSIF"])
@@ -6,22 +6,19 @@ set_mastsif()
 
 # :hs10 removed from the tests because of
 # https://github.com/JuliaSmoothOptimizers/CUTEst.jl/issues/113
-problems = [:brownden, :hs5, :hs6, :hs10, :hs11, :hs14]
-nlpmodels_path = joinpath(dirname(pathof(NLPModels)), "..", "test")
+problems = [:BROWNDEN, :HS5, :HS6, :HS10, :HS11, :HS14]
 
 include("test_core.jl")
 include("test_julia.jl")
 include("coverage.jl")
 
 for problem in problems
-  println("Testing interfaces on problem $problem")
   problem_s = string(problem)
-  include(joinpath(nlpmodels_path, "problems", "$problem_s.jl"))
-  nlp = CUTEstModel(uppercase(problem_s))
-  adnlp = eval(Meta.parse("$(problem)_autodiff"))()
+  nlp = CUTEstModel(problem_s)
+  nlpman = eval(problem)()
 
-  test_nlpinterface(nlp, adnlp)
-  test_coreinterface(nlp, adnlp)
+  test_nlpinterface(nlp, nlpman)
+  test_coreinterface(nlp, nlpman)
   coverage_increase(nlp)
 
   println("Finalizing")

--- a/test/test_memory_of_coord.jl
+++ b/test/test_memory_of_coord.jl
@@ -1,11 +1,9 @@
-include(joinpath(nlpmodels_path, "test_memory_of_coord.jl"))
-
 function test_memory_of_coord()
   @testset "Memory of coordinate inplace functions" begin
     for p in ["BROWNDEN", "HS5", "HS6", "HS10", "HS11", "HS14"]
       @info "Testing $p"
       nlp = CUTEstModel(p)
-      test_memory_of_coord_of_nlp(nlp)
+      coord_memory_nlp(nlp)
       finalize(nlp)
     end
   end

--- a/test/test_view_subarray.jl
+++ b/test/test_view_subarray.jl
@@ -1,13 +1,8 @@
-include(joinpath(nlpmodels_path, "test_view_subarray.jl"))
-
 function test_view_subarray()
   @testset "Test view subarray" begin
     cnlp = CUTEstModel("HS47")
-    scnlp = SlackModel(cnlp)
 
-    for nlp in [cnlp, scnlp]
-      test_view_subarray_nlp(nlp)
-    end
+    view_subarray_nlp(cnlp)
 
     finalize(cnlp)
   end


### PR DESCRIPTION
This Pull Request is only to show the least amount of changes to make CUTEst work with NLPModelsCore and TestUtils. A future commit will aggregate all these TestUtils tests in a single `test/testutils.jl` file.
NLPModels is not being used, so SlackModel and QNModels are not being tested.

cf @dpo @tmigot
