### PR TITLE
Update to NLPModels 0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ CUTEst_jll = "2.0.4"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
-NLPModels = "0.14"
+NLPModels = "0.15"
 julia = "^1.3.0"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,5 +6,5 @@ NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 
 [compat]
 Documenter = "~0.26"
-Krylov = "0.4.0"
-NLPModels = "0.14.0"
+Krylov = "0.7.0"
+NLPModels = "0.15.0"

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -17,8 +17,8 @@ global cutest_instances = 0
 
 export CUTEstModel, sifdecoder, set_mastsif
 
-mutable struct CUTEstModel <: AbstractNLPModel
-  meta    :: NLPModelMeta
+mutable struct CUTEstModel <: AbstractNLPModel{Float64, Vector{Float64}}
+  meta    :: NLPModelMeta{Float64, Vector{Float64}}
   counters :: Counters
   hrows :: Vector{Int32}
   hcols :: Vector{Int32}


### PR DESCRIPTION
CUTEst only works with Float64, so the struct is specialized.
I don't know if it works with GPU. If it does, I can change to `S`.