### PR TITLE
Fix for jac_coord! allocation issue

### DIFF
--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -24,6 +24,7 @@ mutable struct CUTEstModel <: AbstractNLPModel{Float64, Vector{Float64}}
   hcols::Vector{Int32}
   jrows::Vector{Int32}
   jcols::Vector{Int32}
+  work::Vector{Float64}  
 end
 
 const funit = convert(Int32, 42)
@@ -351,7 +352,8 @@ function CUTEstModel(
   hcols = Vector{Int32}(undef, nnzh)
   jrows = Vector{Int32}(undef, nnzj)
   jcols = Vector{Int32}(undef, nnzj)
-  nlp = CUTEstModel(meta, Counters(), hrows, hcols, jrows, jcols)
+  work  = Vector{Int32}(undef, ncon)
+  nlp = CUTEstModel(meta, Counters(), hrows, hcols, jrows, jcols, work)
 
   cutest_instances += 1
   finalizer(cutest_finalize, nlp)

--- a/src/julia_interface.jl
+++ b/src/julia_interface.jl
@@ -113,7 +113,7 @@ function NLPModels.objgrad!(nlp::CUTEstModel, x::AbstractVector, g::AbstractVect
 end
 
 function NLPModels.obj(nlp::CUTEstModel, x::AbstractVector)
-  f = objcons(nlp, x)[1]
+  f = objcons!(nlp, x, nlp.work)[1]
   if nlp.meta.ncon > 0
     nlp.counters.neval_cons -= 1  # does not really count as a constraint eval
   end
@@ -321,8 +321,7 @@ function NLPModels.jac_structure!(
 end
 
 function NLPModels.jac_coord!(nlp::CUTEstModel, x::AbstractVector, vals::AbstractVector)
-  c = Vector{Float64}(undef, nlp.meta.ncon)
-  cons_coord!(nlp, x, c, nlp.jrows, nlp.jcols, vals)
+  cons_coord!(nlp, x, nlp.work, nlp.jrows, nlp.jcols, vals)
   nlp.counters.neval_cons -= 1  # does not really count as a constraint eval
   return vals
 end


### PR DESCRIPTION
This PR implements the changes suggested in #270.

To avoid memory allocation in `NLPModels.jac_coord!` and `NLPModels.obj`, a workspace array is added in `CUTEstModel`. The workspace array is used within `NLPModels.jac_coord!` and `NLPModels.obj` to avoid creating new arrays.

I believe no change in the test is necessary for this PR.