### PR TITLE
use push_preview = true in docs deploy

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,4 +22,5 @@ deploydocs(
   repo = "github.com/JuliaSmoothOptimizers/CUTEst.jl.git",
   target = "build",
   devbranch = "main",
+  push_preview = true,
 )


### PR DESCRIPTION
With this change, a new workflow named "documenter/deploy" appears in the list of checks when the docs have finished building.
Clicking on "details" takes you to the docs resulting from the pull request.