### PR TITLE
Fix unit tests for problem hs14

### DIFF
--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -78,13 +78,15 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel; test_v
     if (ncon[1] > 0)
       cfn(st, nvar, ncon, x0, fx, cx)
       @test isapprox(fx[1], f(x0), rtol = rtol)
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
 
       cifn(st, nvar, Cint[0], x0, fx)
       @test isapprox(fx[1], f(x0), rtol = rtol)
       for i = 1:ncon[1]
         cifn(st, nvar, Cint[i], x0, cx)
-        @test isapprox(cx[1], c(x0)[i], rtol = rtol)
+        #@test isapprox(cx[1], c(x0)[i], rtol = rtol)
+        @test isapprox(cx[1] - nlp.meta.ucon[i], c(x0)[i] - comp_nlp.meta.ucon[i], rtol = rtol)
+        @test isapprox(cx[1] - nlp.meta.lcon[i], c(x0)[i] - comp_nlp.meta.lcon[i], rtol = rtol)
       end
 
       cofg(st, nvar, x0, fx, gx, True)
@@ -166,7 +168,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel; test_v
       for k = 1:nnzj[1]
         Jx[Jfun[k], Jvar[k]] = Jval[k]
       end
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       for j = 1:ncon[1]
@@ -174,7 +176,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel; test_v
         cx[j] = ci[1]
         Jx[j, :] = gci'
       end
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       Jx = zeros(ncon[1], nvar[1])
@@ -185,7 +187,7 @@ function test_coreinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel; test_v
           Jx[j, Jvar[k]] = Jval[k]
         end
       end
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       cgrdh(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar, Wx)

--- a/test/test_julia.jl
+++ b/test/test_julia.jl
@@ -1,3 +1,8 @@
+function compare_cons(nlp1, cx1, nlp2, cx2, rtol)
+  @test isapprox(cx1 - nlp1.meta.ucon, cx2 - nlp2.meta.ucon, rtol = rtol)
+  @test isapprox(cx1 - nlp1.meta.lcon, cx2 - nlp2.meta.lcon, rtol = rtol)
+end
+
 function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
   x0 = nlp.meta.x0
   f(x) = obj(comp_nlp, x)
@@ -30,11 +35,11 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
     if nlp.meta.ncon > 0
       (fx, cx) = objcons(nlp, x0)
       @test isapprox(fx, f(x0), rtol = rtol)
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
 
       (cx, jrow, jcol, jval) = cons_coord(nlp, x0)
       Jx = sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       jac_structure!(nlp)
@@ -48,19 +53,19 @@ function test_nlpinterface(nlp::CUTEstModel, comp_nlp::AbstractNLPModel)
       x[1:2:end] .= x0
       (cx, jrow, jcol, jval) = cons_coord(nlp, @view x[1:2:end])
       Jx = sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       (cx, Jx) = consjac(nlp, x0)
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       cx = cons(nlp, x0) # This is here to improve coverage
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
 
       fill!(cx, 0.0)
       cons!(nlp, x0, cx)
-      @test isapprox(cx, c(x0), rtol = rtol)
+      compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
 
       jval = jac_coord(nlp, x0)
       Jx = sparse(jrow, jcol, jval, nlp.meta.ncon, nlp.meta.nvar)


### PR DESCRIPTION
Since https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/50/files there nonlinear function in NLPModelsTest.jl and CUTEst.jl now differs. So, I suggest to test with the function (defined in this PR) `compare_cons`.

The unit tests then break because of the linear API, see https://github.com/JuliaSmoothOptimizers/CUTEst.jl/tree/add-linear-API (with NLPModelsTest 0.8.1), coming in a following PR