### PR TITLE
Add meta for linear API

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,4 +7,4 @@ NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 [compat]
 Documenter = "~0.26"
 Krylov = "0.7.0"
-NLPModels = "0.17.0"
+NLPModels = "0.18"

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -312,6 +312,7 @@ function CUTEstModel(
   end
 
   lin = findall(linear .!= 0)
+  nlin = length(lin)
 
   nnzh = Cint[0]
   nnzj = Cint[0]
@@ -331,18 +332,23 @@ function CUTEstModel(
   ccall(dlsym(cutest_lib, :fortran_close_), Nothing, (Ref{Int32}, Ptr{Int32}), funit, io_err)
   @cutest_error
 
+  ncon = Int(ncon)
+  nvar = Int(nvar)
+
   meta = NLPModelMeta(
-    Int(nvar),
+    nvar,
     x0 = x,
     lvar = bl,
     uvar = bu,
-    ncon = Int(ncon),
+    ncon = ncon,
     y0 = v,
     lcon = cl,
     ucon = cu,
     nnzj = nnzj,
     nnzh = nnzh,
     lin = lin,
+    lin_nnzj = min(nvar * nlin, nnzj),
+    nln_nnzj = min(nvar * (ncon - nlin), nnzj),
     name = splitext(name)[1],
   )
 


### PR DESCRIPTION
Add `lin_nnzj` and `nln_nnzj` in the meta.
There is no specific API to get the linear jacobian in CUTEst, so I used `nnzj` as an upper bound.

The tests break in this branch, the working one is here: https://github.com/JuliaSmoothOptimizers/CUTEst.jl/tree/add-linear-API