### PR TITLE
Bump to NLPModels 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ CUTEst_jll = "2.0.4"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
-NLPModels = "0.15, 0.16, 0.17, 0.18"
+NLPModels = "0.18, 0.19"
 julia = "^1.3.0"
 
 [extras]


### PR DESCRIPTION
and drop before 0.18 as the linear API wasn't implemented there.