### PR TITLE
Use the new package SIFDecode_jll.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.6', '1']
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         arch: [x64]
         allow_failure: [false]
         include:
@@ -27,7 +27,7 @@ jobs:
             arch: x64
             allow_failure: true
           - version: 'nightly'
-            os: macos-latest
+            os: macos-13
             arch: x64
             allow_failure: true
     steps:
@@ -37,7 +37,7 @@ jobs:
         with:
           compiler: 'gcc'
           version: '11'
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 *.[df]
 *.so
 
+Manifest.toml
+
 deps/*
 !deps/build.jl
 
 docs/build
 docs/site
+dos/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,12 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SIFDecode_jll = "54dcf436-342f-53ea-8005-3708a1ae6c8c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 CUTEst_jll = "=2.0.6"
+SIFDecode_jll = "2.5.1"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ comparing optimization algorithms, derived from the abstract model on
 
 ## How to Cite
 
-If you use CUTEst.jl in your work, please cite using the format given in [CITATION.bib](https://github.com/JuliaSmoothOptimizers/CUTEst.jl/blob/main/CITATION.bib).
+If you use CUTEst.jl in your work, please cite using the format given in [CITATION.cff](https://github.com/JuliaSmoothOptimizers/CUTEst.jl/blob/main/CITATION.cff).
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ comparing optimization algorithms, derived from the abstract model on
 
 ### Stable release [![Github release](https://img.shields.io/github/release/JuliaSmoothOptimizers/CUTEst.jl.svg)](https://github.com/JuliaSmoothOptimizers/CUTEst.jl/releases/latest) [![DOI](https://zenodo.org/badge/30661559.svg)](https://zenodo.org/badge/latestdoi/30661559)
 
-- Documentation: [![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaSmoothOptimizers.github.io/CUTEst.jl/stable)
+- Documentation: [![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://jso.dev/CUTEst.jl/stable)
 - Chat: [![Gitter](https://img.shields.io/gitter/room/JuliaSmoothOptimizers/JuliaSmoothOptimizers.svg)](https://gitter.im/JuliaSmoothOptimizers/JuliaSmoothOptimizers)
 
 ### Development version
 
-- Documentation: [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaSmoothOptimizers.github.io/CUTEst.jl/latest)
+- Documentation: [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://jso.dev/CUTEst.jl/latest)
 - Tests:
 [![Build Status](https://travis-ci.org/JuliaSmoothOptimizers/CUTEst.jl.svg?branch=main)](https://travis-ci.org/JuliaSmoothOptimizers/CUTEst.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaSmoothOptimizers/CUTEst.jl/badge.svg?branch=main)](https://coveralls.io/r/JuliaSmoothOptimizers/CUTEst.jl?branch=main)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1.0"
 NLPModels = "0.20"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,11 +4,11 @@ makedocs(
   modules = [CUTEst],
   doctest = true,
   linkcheck = true,
-  strict = true,
   format = Documenter.HTML(
     assets = ["assets/style.css"],
     ansicolor = true,
     prettyurls = get(ENV, "CI", nothing) == "true",
+    size_threshold_ignore = ["reference.md"],
   ),
   sitename = "CUTEst.jl",
   pages = [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, CUTEst, NLPModels
 
 makedocs(
   modules = [CUTEst],
-  doctest = true,
+  doctest = false,
   linkcheck = true,
   format = Documenter.HTML(
     assets = ["assets/style.css"],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -81,7 +81,7 @@ finalize(nlp)
 ```
 
 Check the [NLPModels
-API](https://JuliaSmoothOptimizers.github.io/NLPModels.jl/stable/api/) for details.
+API](https://jso.dev/NLPModels.jl/stable/api/) for details.
 
 You can pass parameters to sifdecoder by giving additional arguments to `CUTEstModel`.
 For instance, to change `NH` from model `CHAIN`, use

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,1 +1,1 @@
-You can check an [Introduction to CUTEst.jl](https://juliasmoothoptimizers.github.io/tutorials/introduction-to-cutest/) on our [site](https://juliasmoothoptimizers.github.io/).
+You can check an [Introduction to CUTEst.jl](https://jso.dev/tutorials/introduction-to-cutest/) on our [site](https://jso.dev/).

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -245,10 +245,10 @@ You can, for instance, change parameters of the model:
 using CUTEst
 
 nlp = CUTEstModel("CHAIN", "-param", "NH=50")
-println(nlp.meta.nnzh)
+print(nlp.meta.nnzh)
 finalize(nlp)
 nlp = CUTEstModel("CHAIN", "-param", "NH=100")
-println(nlp.meta.nnzh)
+print(nlp.meta.nnzh)
 finalize(nlp)
 
 # output

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -253,6 +253,7 @@ finalize(nlp)
 
 # output
 
+
 153
 303
 ```

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -245,14 +245,13 @@ You can, for instance, change parameters of the model:
 using CUTEst
 
 nlp = CUTEstModel("CHAIN", "-param", "NH=50")
-print(nlp.meta.nnzh)
+println(nlp.meta.nnzh)
 finalize(nlp)
 nlp = CUTEstModel("CHAIN", "-param", "NH=100")
-print(nlp.meta.nnzh)
+println(nlp.meta.nnzh)
 finalize(nlp)
 
 # output
-
 
 153
 303


### PR DESCRIPTION
- Use the new JLL package dedicated to SIFDecode
- Use the latest SIF decoder implemented as a Fortran executable
- Support multiple precision for decoding (`:single`, `:double` and `:quadruple`)
