### PR TITLE
Update Artifacts.toml

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,23 @@
 [sifcollection]
-git-tree-sha1 = "a7ea0d0aaf29a39ca0fe75588fc077cdd5b5ed54"
+git-tree-sha1 = "a39ce7e15e83de78fee4847fa67c5f63e3f0c3c5"
+lazy = true
 
     [[sifcollection.download]]
-    url = "https://bitbucket.org/optrove/sif/get/99c5b38e7d03.tar.gz"
-    sha256 = "33b29e46288c6f019f4ee58e0df6b2797bc2642419b2c181edc574c8db8f6f34"
+    url = "https://bitbucket.org/optrove/sif/get/229e00b81891789fe29f099d1844565ef0ac14d3.tar.gz"
+    sha256 = "6e2cf075ddd4fe715a912847c70efdf2711114b6b1342ad4649edeae25e80b4c"
+
+[maros-meszaros]
+git-tree-sha1 = "0eff5ae5b345db85386f55f672a19c90f23257b2"
+lazy = true
+
+    [[maros-meszaros.download]]
+    url = "https://bitbucket.org/optrove/maros-meszaros/get/9adfb5707b1e0b83a2e0a26cc8310704ff01b7c1.tar.gz"
+    sha256 = "1bdb9df59502c2f24ae23303f70b2edbdf54660c1db88a048c230e4d3ab851c3"
+
+[netlib-lp]
+git-tree-sha1 = "545f8c5577a056981a21caf3f53bd7b59cf67410"
+lazy = true
+
+    [[netlib-lp.download]]
+    url = "https://bitbucket.org/optrove/netlib-lp/get/f83996fca9370b23d8896f134c4dfe7adbaca0ec.tar.gz"
+    sha256 = "e5b7d4128a0bde757ac59182228f80a33828ccc62c1764a33de722b096c0dd9a"

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -81,9 +81,6 @@ function __init__()
   # set default MASTSIF location if the user hasn't set it already
   if !("MASTSIF" ∈ keys(ENV))
     ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
-    # Path for the other sets of SIF problems:
-    # ENV["MASTSIF"] = joinpath(artifact"maros-meszaros", "optrove-maros-meszaros-9adfb5707b1e")
-    # ENV["MASTSIF"] = joinpath(artifact"netlib-lp", "optrove-netlib-lp-f83996fca937")
   else
     @info "call set_mastsif() to use the full SIF collection"
   end
@@ -114,7 +111,10 @@ include("classification.jl")
 Set the MASTSIF environment variable to point to the main SIF collection.
 """
 function set_mastsif()
-  ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-99c5b38e7d03")
+  ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
+  # Path for the other sets of SIF problems:
+  # ENV["MASTSIF"] = joinpath(artifact"maros-meszaros", "optrove-maros-meszaros-9adfb5707b1e")
+  # ENV["MASTSIF"] = joinpath(artifact"netlib-lp", "optrove-netlib-lp-f83996fca937")
   @info "using full SIF collection located at" ENV["MASTSIF"]
   nothing
 end

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -80,7 +80,10 @@ function __init__()
 
   # set default MASTSIF location if the user hasn't set it already
   if !("MASTSIF" ∈ keys(ENV))
-    ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-99c5b38e7d03")
+    ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
+    # Path for the other sets of SIF problems:
+    # ENV["MASTSIF"] = joinpath(artifact"maros-meszaros", "optrove-maros-meszaros-9adfb5707b1e")
+    # ENV["MASTSIF"] = joinpath(artifact"netlib-lp", "optrove-netlib-lp-f83996fca937")
   else
     @info "call set_mastsif() to use the full SIF collection"
   end

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -79,8 +79,8 @@ function __init__()
   end
 
   # set default MASTSIF location if the user hasn't set it already
-  if !("MASTSIF" ∈ keys(ENV))
-    ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
+  if !haskey(ENV, "MASTSIF")
+    set_mastsif()
   else
     @info "call set_mastsif() to use the full SIF collection"
   end
@@ -106,17 +106,27 @@ include("julia_interface.jl")
 include("classification.jl")
 
 """
-    set_mastsif()
+    set_mastsif(set::String="sifcollection")
 
-Set the MASTSIF environment variable to point to the main SIF collection.
+Set the MASTSIF environment variable to point to a set of SIF problems.
+The supported sets are:
+- "sifcollection": the CUTEst NLP test set;
+- "maros-meszaros": the Maros-Meszaros QP test set;
+- "netlib-lp": the Netlib LP test set.
+
 """
-function set_mastsif()
-  ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
-  # Path for the other sets of SIF problems:
-  # ENV["MASTSIF"] = joinpath(artifact"maros-meszaros", "optrove-maros-meszaros-9adfb5707b1e")
-  # ENV["MASTSIF"] = joinpath(artifact"netlib-lp", "optrove-netlib-lp-f83996fca937")
+function set_mastsif(set::String="sifcollection")
+  if set == "sifcollection"
+    ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
+  elseif set == "maros-meszaros"
+    ENV["MASTSIF"] = joinpath(artifact"maros-meszaros", "optrove-maros-meszaros-9adfb5707b1e")
+  elseif set == "netlib-lp"
+    ENV["MASTSIF"] = joinpath(artifact"netlib-lp", "optrove-netlib-lp-f83996fca937")
+  else
+    error("The set $set is not supported.")
+  end
   @info "using full SIF collection located at" ENV["MASTSIF"]
-  nothing
+  return nothing
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,3 +83,8 @@ if !Sys.iswindows()
     end
   end
 end
+
+# test set_mastsif
+for set in ("sifcollection", "maros-meszaros", "netlib-lp")
+  set_mastsif(set)
+end


### PR DESCRIPTION
Related to #337 
- Use the last release of the `sifcollection` added yesterday by Nick.
- Add two new artifacts for LP and QP problems (`netlib-lp` and `maros-meszaros`).
- Add an attribute `lazy=true` to only download an artifact if we need it.

For example, we should not download any artifact if the user defines the environment variable `MASTSIF`.

Note that the new standalone decoder available in `SIFDecode_jll.jl` and used since `CUTEst_jll.jl` v0.13.3 is tested on all these problems: https://github.com/ralna/SIFDecode/pull/20
I tested it with `single`, `double` and `quadruple` precision.

We could update the function `set_matsif` to provide an option to switch between `sifcollection`, `maros-meszaros` and `netlib-lp` sets in a future PR. 