### PR TITLE
Add a standalone sifdecoder function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.6', '1']
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-13]
         arch: [x64]
         allow_failure: [false]
         include:
@@ -24,6 +24,10 @@ jobs:
             allow_failure: false
           - version: 'nightly'
             os: ubuntu-latest
+            arch: x64
+            allow_failure: true
+          - version: 'nightly'
+            os: windows-latest
             arch: x64
             allow_failure: true
           - version: 'nightly'

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -76,7 +76,7 @@ function sifdecoder(
     if verbose
       read(outlog, String) |> println
     end
-    isfile("OUTSIF.d") && run(`mv OUTSDIF.d $outsdif`)
+    isfile("OUTSDIF.d") && run(`mv OUTSDIF.d $outsdif`)
   end
   rm(outlog)
   rm(errlog)

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -1,0 +1,135 @@
+function delete_temp_files(suffix::String)
+  for f in (
+    "ELFUN",
+    "ELFUNF",
+    "ELFUND",
+    "RANGE",
+    "GROUP",
+    "GROUPF",
+    "GROUPD",
+    "SETTYP",
+    "EXTER",
+    "EXTERA",
+  )
+    for ext in ("f", "o")
+      fname = "$f$suffix.$ext"
+      isfile(fname) && rm(fname, force = true)
+    end
+  end
+  isfile("OUTSDIF.d") && rm("OUTSDIF.d", force = true)
+  nothing
+end
+
+"""Decode a SIF problem.
+
+Optional arguments are passed directly to the SIF decoder.
+Example:
+    `sifdecoder("DIXMAANJ", "-param", "M=30")`.
+"""
+function sifdecoder(
+  name::AbstractString,
+  args...;
+  verbose::Bool = false,
+  outsdif::String = "OUTSDIF_$(basename(name)).d",
+  precision::Symbol = :double,
+)
+  if precision == :single
+    prec = "-sp"
+    suffix = "_s"
+  elseif precision == :double
+    prec = "-dp"
+    suffix = ""
+  elseif precision == :quadruple
+    prec = "-qp"
+    suffix = "_q"
+  else
+    error("The $precision precision is not supported.")
+  end
+
+  if length(name) < 4 || name[(end - 3):end] != ".SIF"
+    name = "$name.SIF"
+  end
+  if isfile(name)
+    path_sifname = abspath(name)
+  else
+    path_sifname = joinpath(ENV["MASTSIF"], name)
+    if !isfile(path_sifname)
+      error("$name not found")
+    end
+  end
+
+  outlog = tempname()
+  errlog = tempname()
+  cd(cutest_problems_path) do
+    delete_temp_files(suffix)
+    run(
+      pipeline(
+        Cmd(
+          `$(SIFDecode_jll.sifdecoder_standalone()) $(args) $(prec) $(path_sifname)`,
+          ignorestatus = true,
+        ),
+        stdout = outlog,
+        stderr = errlog,
+      ),
+    )
+    read(errlog, String) |> println
+    if verbose
+      read(outlog, String) |> println
+    end
+  end
+  rm(outlog)
+  rm(errlog)
+  nothing
+end
+
+"""
+Build a shared library from a decoded SIF problem.
+
+Example:
+    `build_libsif("DIXMAANJ")`.
+"""
+function build_libsif(name::AbstractString; precision::Symbol = :double)
+  if precision == :single
+    prec = "-sp"
+    suffix = "_s"
+  elseif precision == :double
+    prec = "-dp"
+    suffix = ""
+  elseif precision == :quadruple
+    prec = "-qp"
+    suffix = "_q"
+  else
+    error("The $precision precision is not supported.")
+  end
+
+  pname, sif = basename(name) |> splitext
+  libname = "lib$pname"
+
+  cd(cutest_problems_path) do
+    if isfile("ELFUN$suffix.f")
+      run(`gfortran -c -fPIC ELFUN$suffix.f`)
+      object_files = ["ELFUN$suffix.o"]
+      for file in
+          ("GROUP", "RANGE", "ELFUNF", "ELFUND", "GROUPF", "GROUPD", "SETTYP", "EXTER", "EXTERA")
+        if isfile("$file$suffix.f")
+          run(`gfortran -c -fPIC $file$suffix.f`)
+          push!(object_files, "$file$suffix.o")
+        end
+      end
+      if Sys.isapple()
+        run(
+          `$linker $sh_flags -o $libname.$(Libdl.dlext) $(object_files) -Wl,-rpath $libpath $(joinpath(libpath, "libcutest_double.$(Libdl.dlext)")) $libgfortran`,
+        )
+      else
+        run(
+          `$linker $sh_flags -o $libname.$(Libdl.dlext) $(object_files) -rpath=$libpath -L$libpath -lcutest_double $libgfortran`,
+        )
+      end
+      run(`mv OUTSDIF.d $outsdif`)
+      delete_temp_files(suffix)
+      global cutest_lib =
+        Libdl.dlopen(libname, Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
+      global cutest_lib_path = joinpath(cutest_problems_path, "$libname.$(Libdl.dlext)")
+    end
+  end
+end

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -76,6 +76,7 @@ function sifdecoder(
     if verbose
       read(outlog, String) |> println
     end
+    isfile("OUTSIF.d") && run(`mv OUTSDIF.d $outsdif`)
   end
   rm(outlog)
   rm(errlog)
@@ -125,7 +126,6 @@ function build_libsif(name::AbstractString; precision::Symbol = :double)
           `$linker $sh_flags -o $libname.$(Libdl.dlext) $(object_files) -rpath=$libpath -L$libpath -lcutest_double $libgfortran`,
         )
       end
-      run(`mv OUTSDIF.d $outsdif`)
       delete_temp_files(suffix)
       global cutest_lib =
         Libdl.dlopen(libname, Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -32,6 +32,7 @@ function sifdecoder(
   verbose::Bool = false,
   outsdif::String = "OUTSDIF_$(basename(name)).d",
   precision::Symbol = :double,
+  libsif_folder::String = cutest_problems_path
 )
   if precision == :single
     prec = "-sp"
@@ -60,7 +61,7 @@ function sifdecoder(
 
   outlog = tempname()
   errlog = tempname()
-  cd(cutest_problems_path) do
+  cd(libsif_folder) do
     delete_temp_files(suffix)
     run(
       pipeline(
@@ -89,7 +90,11 @@ Build a shared library from a decoded SIF problem.
 Example:
     `build_libsif("DIXMAANJ")`.
 """
-function build_libsif(name::AbstractString; precision::Symbol = :double)
+function build_libsif(
+  name::AbstractString;
+  precision::Symbol = :double,
+  libsif_folder::String = cutest_problems_path
+)
   if precision == :single
     prec = "-sp"
     suffix = "_s"
@@ -106,7 +111,7 @@ function build_libsif(name::AbstractString; precision::Symbol = :double)
   pname, sif = basename(name) |> splitext
   libname = "lib$pname"
 
-  cd(cutest_problems_path) do
+  cd(libsif_folder) do
     if isfile("ELFUN$suffix.f")
       run(`gfortran -c -fPIC ELFUN$suffix.f`)
       object_files = ["ELFUN$suffix.o"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ problems = ["BROWNDEN", "HS5", "HS6", "HS10", "HS11", "HS13", "HS14"]
 # test sifdecoder
 for pb in problems
   for precision in (:single, :double, :quadruple)
-    sifdecoder(pb, verbose=true, precision=precision)
+    sifdecoder(pb, precision=precision)
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,72 +6,80 @@ using CUTEst, NLPModels, NLPModelsTest
 set_mastsif()
 @test ispath(ENV["MASTSIF"])
 @test isfile(joinpath(ENV["MASTSIF"], "CYCLOOCT.SIF"))
-
 problems = ["BROWNDEN", "HS5", "HS6", "HS10", "HS11", "HS13", "HS14"]
 
-include("test_core.jl")
-include("test_julia.jl")
-include("coverage.jl")
-
-for problem in problems
-  println("Testing interfaces on problem $problem")
-  nlp = CUTEstModel(problem)
-  nlp_man = eval(Symbol(problem))()
-
-  test_nlpinterface(nlp, nlp_man)
-  test_coreinterface(nlp, nlp_man)
-  test_coreinterface(nlp, nlp_man; test_view = true)
-  coverage_increase(nlp)
-
-  println("Finalizing")
-  finalize(nlp)
+# test sifdecoder
+for pb in problems
+  for precision in (:single, :double, :quadruple)
+    sifdecoder(pb, precision=precision)
+  end
 end
 
-include("nlpmodelstest.jl")
-# include("test_select.jl") # Tests are removed because any update to MASTSIF breaks it
+if !Sys.iswindows()
+  include("test_core.jl")
+  include("test_julia.jl")
+  include("coverage.jl")
 
-problems = CUTEst.select(max_var = 2, max_con = 2)
-problems = randsubseq(problems, 0.1)
+  for problem in problems
+    println("Testing interfaces on problem $problem")
+    nlp = CUTEstModel(problem)
+    nlp_man = eval(Symbol(problem))()
 
-for p in problems
-  nlp = CUTEstModel(p)
-  x0 = nlp.meta.x0
-  nvar, ncon = nlp.meta.nvar, nlp.meta.ncon
+    test_nlpinterface(nlp, nlp_man)
+    test_coreinterface(nlp, nlp_man)
+    test_coreinterface(nlp, nlp_man; test_view = true)
+    coverage_increase(nlp)
 
-  println("$p: julia interface: f(x₀) = $(obj(nlp, x0))")
-
-  io_err = Cint[0]
-  fval = [0.0]
-  if ncon > 0
-    cx = zeros(ncon)
-    cfn(io_err, Cint[nvar], Cint[ncon], x0, fval, cx)
-  else
-    ufn(io_err, Cint[nvar], x0, fval)
-  end
-  println("$p: core interface: f(x₀) = $(fval[1])")
-
-  finalize(nlp)
-end
-
-# test arguments passed to decoder
-nlp = CUTEstModel("DIXMAANJ", "-param", "M=5")
-@assert nlp.meta.nvar == 15
-finalize(nlp)
-
-nlp = CUTEstModel("DIXMAANJ", "-param", "M=30")
-@assert nlp.meta.nvar == 90
-finalize(nlp)
-
-@testset "Test decoding separately (issue #239)" begin
-  problems = ["AKIVA", "ROSENBR", "ZANGWIL2"]
-  # Decoding
-  for p in problems
-    finalize(CUTEstModel(p))
-  end
-  # No decode
-  for p in problems
-    nlp = CUTEstModel(p, decode = false)
-    @test nlp.meta.nvar == 2
+    println("Finalizing")
     finalize(nlp)
+  end
+
+  include("nlpmodelstest.jl")
+  # include("test_select.jl") # Tests are removed because any update to MASTSIF breaks it
+
+  problems = CUTEst.select(max_var = 2, max_con = 2)
+  problems = randsubseq(problems, 0.1)
+
+  for p in problems
+    nlp = CUTEstModel(p)
+    x0 = nlp.meta.x0
+    nvar, ncon = nlp.meta.nvar, nlp.meta.ncon
+
+    println("$p: julia interface: f(x₀) = $(obj(nlp, x0))")
+
+    io_err = Cint[0]
+    fval = [0.0]
+    if ncon > 0
+      cx = zeros(ncon)
+      cfn(io_err, Cint[nvar], Cint[ncon], x0, fval, cx)
+    else
+      ufn(io_err, Cint[nvar], x0, fval)
+    end
+    println("$p: core interface: f(x₀) = $(fval[1])")
+
+    finalize(nlp)
+  end
+
+  # test arguments passed to decoder
+  nlp = CUTEstModel("DIXMAANJ", "-param", "M=5")
+  @assert nlp.meta.nvar == 15
+  finalize(nlp)
+
+  nlp = CUTEstModel("DIXMAANJ", "-param", "M=30")
+  @assert nlp.meta.nvar == 90
+  finalize(nlp)
+
+  @testset "Test decoding separately (issue #239)" begin
+    problems = ["AKIVA", "ROSENBR", "ZANGWIL2"]
+    # Decoding
+    for p in problems
+      finalize(CUTEstModel(p))
+    end
+    # No decode
+    for p in problems
+      nlp = CUTEstModel(p, decode = false)
+      @test nlp.meta.nvar == 2
+      finalize(nlp)
+    end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ problems = ["BROWNDEN", "HS5", "HS6", "HS10", "HS11", "HS13", "HS14"]
 # test sifdecoder
 for pb in problems
   for precision in (:single, :double, :quadruple)
-    sifdecoder(pb, precision=precision)
+    sifdecoder(pb, verbose=true, precision=precision)
   end
 end
 


### PR DESCRIPTION
close #335 

- Add a new file `sifdecoder.jl`
- Split the previous function `sifdecoder` into two new functions `sifdecoder` and `build_libsif`
- Add CI on Windows
- Test the new function `sifdecoder` on all platforms
- Add an option `libsif_folder` to specify where we want to decode the SIF problems and build the shared libraries
