### PR TITLE
Update the sifcollection in Artifacts.toml

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,10 +1,10 @@
 [sifcollection]
-git-tree-sha1 = "a39ce7e15e83de78fee4847fa67c5f63e3f0c3c5"
+git-tree-sha1 = "8abf878b5b5679ac70946a6a1bf6a55805f63fc6"
 lazy = true
 
     [[sifcollection.download]]
-    url = "https://bitbucket.org/optrove/sif/get/229e00b81891789fe29f099d1844565ef0ac14d3.tar.gz"
-    sha256 = "6e2cf075ddd4fe715a912847c70efdf2711114b6b1342ad4649edeae25e80b4c"
+    url = "https://bitbucket.org/optrove/sif/get/c71425cc7f54ddda53ab57c11290a1cbf53aaf17.tar.gz"
+    sha256 = "29de55f04a2c88757dee7c0901eb0f77a90f43642f3bd4bab15c0bcc0ccb5f89"
 
 [maros-meszaros]
 git-tree-sha1 = "0eff5ae5b345db85386f55f672a19c90f23257b2"

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -10,7 +10,7 @@ The supported sets are:
 """
 function set_mastsif(set::String = "sifcollection")
   if set == "sifcollection"
-    ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-229e00b81891")
+    ENV["MASTSIF"] = joinpath(artifact"sifcollection", "optrove-sif-c71425cc7f54")
   elseif set == "maros-meszaros"
     ENV["MASTSIF"] = joinpath(artifact"maros-meszaros", "optrove-maros-meszaros-9adfb5707b1e")
   elseif set == "netlib-lp"


### PR DESCRIPTION
close #337 

We fixed the last bugs in the SIF files and the decoder such that all problems can be decoded in `single`, `double` or `quadruple` precision with Nick.

A new release of `SIFDecode_jll.jl` is also needed but it will be in another PR.