### PR TITLE
Use the version 2.6.0 of SIFDecode_jll.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 CUTEst_jll = "=2.0.7"
-SIFDecode_jll = "2.5.1"
+SIFDecode_jll = "2.6.0"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"


### PR DESCRIPTION
This version allows to decode all SIF problems in single, double and quadruple precision.