### PR TITLE
Use CUTEst_jll.jl v2.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SIFDecode_jll = "54dcf436-342f-53ea-8005-3708a1ae6c8c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUTEst_jll = "=2.0.7"
+CUTEst_jll = "=2.2.2"
 SIFDecode_jll = "2.6.0"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -5,4 +5,4 @@ JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 
 [compat]
 julia = "1.6"
-CUTEst_jll = "2.2.0"
+CUTEst_jll = "2.2.2"

--- a/gen/wrapper.jl
+++ b/gen/wrapper.jl
@@ -6,7 +6,7 @@ using JuliaFormatter
 
 function main()
   cd(@__DIR__)
-  include_dir = "/home/alexis/Applications/CUTEst/include"  # joinpath(CUTEst_jll.artifact_dir, "include")
+  include_dir = joinpath(CUTEst_jll.artifact_dir, "include")
   headers = map(header -> joinpath(include_dir, header), ["cutest.h"])
 
   options = load_options(joinpath(@__DIR__, "cutest.toml"))

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -10,13 +10,15 @@ function coverage_increase(nlp::CUTEstModel{Float64})
   varnames(Float64, status, Cint[n], vname)
   if m == 0
     unames(Float64, status, Cint[n], pname, vname)
-    calls, time = Vector{Float64}(undef, 4), Vector{Float64}(undef, 2)
+    calls = Vector{Float64}(undef, 4)
+    time = Vector{Float64}(undef, 4)
     ureport(Float64, status, calls, time)
   else
     cname = Matrix{Cchar}(undef, 10, m)
     connames(Float64, status, Cint[m], cname)
     cnames(Float64, status, Cint[n], Cint[m], pname, vname, cname)
-    calls, time = Vector{Float64}(undef, 7), Vector{Float64}(undef, 2)
+    calls = Vector{Float64}(undef, 7)
+    time = Vector{Float64}(undef, 4)
     creport(Float64, status, calls, time)
     nvo, nvc, ec, lc = Cint[0], Cint[0], Cint[0], Cint[0]
     cstats(Float64, status, nvo, nvc, ec, lc)


### PR DESCRIPTION
- It's a big upgrade for `CUTEst_jll.jl`; the previous version was a few years old...
- CUTEst deallocates memory that it should not free... (the issue is between releases `v2.0.7` and `v2.0.27`)