### PR TITLE
Interface routines for quadruple precision

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 NLPModels = "0.18, 0.19, 0.20"
+Quadmath = "0.5.10"
 SIFDecode_jll = "2.6.0"
 julia = "^1.6.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,16 +10,17 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Quadmath = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
 SIFDecode_jll = "54dcf436-342f-53ea-8005-3708a1ae6c8c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 CUTEst_jll = "=2.2.2"
-SIFDecode_jll = "2.6.0"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 NLPModels = "0.18, 0.19, 0.20"
+SIFDecode_jll = "2.6.0"
 julia = "^1.6.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SIFDecode_jll = "54dcf436-342f-53ea-8005-3708a1ae6c8c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUTEst_jll = "=2.2.2"
+CUTEst_jll = "=2.2.3"
 Combinatorics = "1.0"
 DataStructures = "0.17, 0.18"
 JSON = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -5,10 +5,7 @@ using CUTEst_jll
 import SIFDecode_jll
 using Pkg.Artifacts
 using Libdl
-
 using Quadmath
-import Quadmath.Cfloat128
-
 using NLPModels
 import Libdl.dlsym
 

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -6,6 +6,9 @@ import SIFDecode_jll
 using Pkg.Artifacts
 using Libdl
 
+using Quadmath
+import Quadmath.Cfloat128
+
 using NLPModels
 import Libdl.dlsym
 

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -97,7 +97,7 @@ Usage:
 """
 function usetup end
 
-for (cutest_usetup, T) in ((:cutest_usetup_s_, :Float32), (:cutest_usetup_, :Float64))
+for (cutest_usetup, T) in ((:cutest_usetup_s_, :Float32), (:cutest_usetup_, :Float64), (:cutest_usetup_q_, :Float128))
   @eval begin
     function usetup(
       ::Type{$T},
@@ -155,7 +155,7 @@ linear, e_order, l_order, v_order)
 function csetup end
 
 for (cutest_cint_csetup, T) in
-    ((:cutest_cint_csetup_s_, :Float32), (:cutest_cint_csetup_, :Float64))
+    ((:cutest_cint_csetup_s_, :Float32), (:cutest_cint_csetup_, :Float64), (:cutest_cint_csetup_q_, :Float128))
   @eval begin
     function csetup(
       ::Type{$T},
@@ -221,7 +221,7 @@ Usage:
 """
 function udimen end
 
-for (cutest_udimen, T) in ((:cutest_udimen_s_, :Float32), (:cutest_udimen_, :Float64))
+for (cutest_udimen, T) in ((:cutest_udimen_s_, :Float32), (:cutest_udimen_, :Float64), (:cutest_udimen_q_, :Float128))
   @eval begin
     function udimen(
       ::Type{$T},
@@ -256,7 +256,7 @@ Usage:
 """
 function udimsh end
 
-for (cutest_udimsh, T) in ((:cutest_udimsh_s_, :Float32), (:cutest_udimsh_, :Float64))
+for (cutest_udimsh, T) in ((:cutest_udimsh_s_, :Float32), (:cutest_udimsh_, :Float64), (:cutest_udimsh_q_, :Float128))
   @eval begin
     function udimsh(::Type{$T}, status::StrideOneVector{Cint}, nnzh::StrideOneVector{Cint})
       $cutest_udimsh(status, nnzh)
@@ -290,7 +290,7 @@ Usage:
 """
 function udimse end
 
-for (cutest_udimse, T) in ((:cutest_udimse_s_, :Float32), (:cutest_udimse_, :Float64))
+for (cutest_udimse, T) in ((:cutest_udimse_s_, :Float32), (:cutest_udimse_, :Float64), (:cutest_udimse_q_, :Float128))
   @eval begin
     function udimse(
       ::Type{$T},
@@ -326,7 +326,7 @@ Usage:
 """
 function uvartype end
 
-for (cutest_uvartype, T) in ((:cutest_uvartype_s_, :Float32), (:cutest_uvartype_, :Float64))
+for (cutest_uvartype, T) in ((:cutest_uvartype_s_, :Float32), (:cutest_uvartype_, :Float64), (:cutest_uvartype_q_, :Float128))
   @eval begin
     function uvartype(
       ::Type{$T},
@@ -362,7 +362,7 @@ To get useful names, use `String(x)` where `x` can be `pname` or `vname[:,i]`.
 """
 function unames end
 
-for (cutest_unames, T) in ((:cutest_unames_s_, :Float32), (:cutest_unames_, :Float64))
+for (cutest_unames, T) in ((:cutest_unames_s_, :Float32), (:cutest_unames_, :Float64), (:cutest_unames_q_, :Float128))
   @eval begin
     function unames(
       ::Type{$T},
@@ -398,7 +398,7 @@ Usage:
 """
 function ureport end
 
-for (cutest_ureport, T) in ((:cutest_ureport_s_, :Float32), (:cutest_ureport_, :Float64))
+for (cutest_ureport, T) in ((:cutest_ureport_s_, :Float32), (:cutest_ureport_, :Float64), (:cutest_ureport_q_, :Float128))
   @eval begin
     function ureport(
       ::Type{$T},
@@ -436,7 +436,7 @@ Usage:
 """
 function cdimen end
 
-for (cutest_cdimen, T) in ((:cutest_cdimen_s_, :Float32), (:cutest_cdimen_, :Float64))
+for (cutest_cdimen, T) in ((:cutest_cdimen_s_, :Float32), (:cutest_cdimen_, :Float64), (:cutest_cdimen_q_, :Float128))
   @eval begin
     function cdimen(
       ::Type{$T},
@@ -475,7 +475,7 @@ Usage:
 """
 function cdimsj end
 
-for (cutest_cdimsj, T) in ((:cutest_cdimsj_s_, :Float32), (:cutest_cdimsj_, :Float64))
+for (cutest_cdimsj, T) in ((:cutest_cdimsj_s_, :Float32), (:cutest_cdimsj_, :Float64), (:cutest_cdimsj_q_, :Float128))
   @eval begin
     function cdimsj(::Type{$T}, status::StrideOneVector{Cint}, nnzj::StrideOneVector{Cint})
       $cutest_cdimsj(status, nnzj)
@@ -507,7 +507,7 @@ Usage:
 """
 function cdimsh end
 
-for (cutest_cdimsh, T) in ((:cutest_cdimsh_s_, :Float32), (:cutest_cdimsh_, :Float64))
+for (cutest_cdimsh, T) in ((:cutest_cdimsh_s_, :Float32), (:cutest_cdimsh_, :Float64), (:cutest_cdimsh_q_, :Float128))
   @eval begin
     function cdimsh(::Type{$T}, status::StrideOneVector{Cint}, nnzh::StrideOneVector{Cint})
       $cutest_cdimsh(status, nnzh)
@@ -539,7 +539,7 @@ Usage:
 """
 function cdimchp end
 
-for (cutest_cdimchp, T) in ((:cutest_cdimchp_s_, :Float32), (:cutest_cdimchp_, :Float64))
+for (cutest_cdimchp, T) in ((:cutest_cdimchp_s_, :Float32), (:cutest_cdimchp_, :Float64), (:cutest_cdimchp_q_, :Float128))
   @eval begin
     function cdimchp(::Type{$T}, status::StrideOneVector{Cint}, nnzchp::StrideOneVector{Cint})
       $cutest_cdimchp(status, nnzchp)
@@ -575,7 +575,7 @@ Usage:
 """
 function cdimse end
 
-for (cutest_cdimse, T) in ((:cutest_cdimse_s_, :Float32), (:cutest_cdimse_, :Float64))
+for (cutest_cdimse, T) in ((:cutest_cdimse_s_, :Float32), (:cutest_cdimse_, :Float64), (:cutest_cdimse_q_, :Float128))
   @eval begin
     function cdimse(
       ::Type{$T},
@@ -602,7 +602,7 @@ linear_constraints)
 """
 function cstats end
 
-for (cutest_cstats, T) in ((:cutest_cstats_s_, :Float32), (:cutest_cstats_, :Float64))
+for (cutest_cstats, T) in ((:cutest_cstats_s_, :Float32), (:cutest_cstats_, :Float64), (:cutest_cstats_q_, :Float128))
   @eval begin
     function cstats(
       ::Type{$T},
@@ -647,7 +647,7 @@ Usage:
 """
 function cvartype end
 
-for (cutest_cvartype, T) in ((:cutest_cvartype_s_, :Float32), (:cutest_cvartype_, :Float64))
+for (cutest_cvartype, T) in ((:cutest_cvartype_s_, :Float32), (:cutest_cvartype_, :Float64), (:cutest_cvartype_q_, :Float128))
   @eval begin
     function cvartype(
       ::Type{$T},
@@ -689,7 +689,7 @@ or `cname[:,i]`.
 """
 function cnames end
 
-for (cutest_cnames, T) in ((:cutest_cnames_s_, :Float32), (:cutest_cnames_, :Float64))
+for (cutest_cnames, T) in ((:cutest_cnames_s_, :Float32), (:cutest_cnames_, :Float64), (:cutest_cnames_q_, :Float128))
   @eval begin
     function cnames(
       ::Type{$T},
@@ -729,7 +729,7 @@ Usage:
 """
 function creport end
 
-for (cutest_creport, T) in ((:cutest_creport_s_, :Float32), (:cutest_creport_, :Float64))
+for (cutest_creport, T) in ((:cutest_creport_s_, :Float32), (:cutest_creport_, :Float64), (:cutest_creport_q_, :Float128))
   @eval begin
     function creport(
       ::Type{$T},
@@ -767,7 +767,7 @@ To get useful names, use `String(cname[:,i])`.
 """
 function connames end
 
-for (cutest_connames, T) in ((:cutest_connames_s_, :Float32), (:cutest_connames_, :Float64))
+for (cutest_connames, T) in ((:cutest_connames_s_, :Float32), (:cutest_connames_, :Float64), (:cutest_connames_q_, :Float128))
   @eval begin
     function connames(
       ::Type{$T},
@@ -804,7 +804,7 @@ Usage:
 """
 function pname end
 
-for (cutest_pname, T) in ((:cutest_pname_s_, :Float32), (:cutest_pname_, :Float64))
+for (cutest_pname, T) in ((:cutest_pname_s_, :Float32), (:cutest_pname_, :Float64), (:cutest_pname_q_, :Float128))
   @eval begin
     function pname(
       ::Type{$T},
@@ -840,7 +840,7 @@ To get a useful name, use `String(pname)`.
 """
 function probname end
 
-for (cutest_probname, T) in ((:cutest_probname_s_, :Float32), (:cutest_probname_, :Float64))
+for (cutest_probname, T) in ((:cutest_probname_s_, :Float32), (:cutest_probname_, :Float64), (:cutest_probname_q_, :Float128))
   @eval begin
     function probname(::Type{$T}, status::StrideOneVector{Cint}, pname::StrideOneVector{Cchar})
       $cutest_probname(status, pname)
@@ -873,7 +873,7 @@ To get useful names, use `String(vname[:, i])`.
 """
 function varnames end
 
-for (cutest_varnames, T) in ((:cutest_varnames_s_, :Float32), (:cutest_varnames_, :Float64))
+for (cutest_varnames, T) in ((:cutest_varnames_s_, :Float32), (:cutest_varnames_, :Float64), (:cutest_varnames_q_, :Float128))
   @eval begin
     function varnames(
       ::Type{$T},
@@ -908,7 +908,7 @@ Usage:
 """
 function ufn end
 
-for (cutest_ufn, T) in ((:cutest_ufn_s_, :Float32), (:cutest_ufn_, :Float64))
+for (cutest_ufn, T) in ((:cutest_ufn_s_, :Float32), (:cutest_ufn_, :Float64), (:cutest_ufn_q_, :Float128))
   @eval begin
     function ufn(
       ::Type{$T},
@@ -944,7 +944,7 @@ Usage:
 """
 function ugr end
 
-for (cutest_ugr, T) in ((:cutest_ugr_s_, :Float32), (:cutest_ugr_, :Float64))
+for (cutest_ugr, T) in ((:cutest_ugr_s_, :Float32), (:cutest_ugr_, :Float64), (:cutest_ugr_q_, :Float128))
   @eval begin
     function ugr(
       ::Type{$T},
@@ -983,7 +983,7 @@ Usage:
 """
 function uofg end
 
-for (cutest_cint_uofg, T) in ((:cutest_cint_uofg_s_, :Float32), (:cutest_cint_uofg_, :Float64))
+for (cutest_cint_uofg, T) in ((:cutest_cint_uofg_s_, :Float32), (:cutest_cint_uofg_, :Float64), (:cutest_cint_uofg_q_, :Float128))
   @eval begin
     function uofg(
       ::Type{$T},
@@ -1023,7 +1023,7 @@ Usage:
 """
 function udh end
 
-for (cutest_udh, T) in ((:cutest_udh_s_, :Float32), (:cutest_udh_, :Float64))
+for (cutest_udh, T) in ((:cutest_udh_s_, :Float32), (:cutest_udh_, :Float64), (:cutest_udh_q_, :Float128))
   @eval begin
     function udh(
       ::Type{$T},
@@ -1063,7 +1063,7 @@ Usage:
 """
 function ushp end
 
-for (cutest_ushp, T) in ((:cutest_ushp_s_, :Float32), (:cutest_ushp_, :Float64))
+for (cutest_ushp, T) in ((:cutest_ushp_s_, :Float32), (:cutest_ushp_, :Float64), (:cutest_ushp_q_, :Float128))
   @eval begin
     function ushp(
       ::Type{$T},
@@ -1107,7 +1107,7 @@ Usage:
 """
 function ush end
 
-for (cutest_ush, T) in ((:cutest_ush_s_, :Float32), (:cutest_ush_, :Float64))
+for (cutest_ush, T) in ((:cutest_ush_s_, :Float32), (:cutest_ush_, :Float64), (:cutest_ush_q_, :Float128))
   @eval begin
     function ush(
       ::Type{$T},
@@ -1159,7 +1159,7 @@ lhe_val, he_val, byrows)
 """
 function ueh end
 
-for (cutest_cint_ueh, T) in ((:cutest_cint_ueh_s_, :Float32), (:cutest_cint_ueh_, :Float64))
+for (cutest_cint_ueh, T) in ((:cutest_cint_ueh_s_, :Float32), (:cutest_cint_ueh_, :Float64), (:cutest_cint_ueh_q_, :Float128))
   @eval begin
     function ueh(
       ::Type{$T},
@@ -1220,7 +1220,7 @@ Usage:
 """
 function ugrdh end
 
-for (cutest_ugrdh, T) in ((:cutest_ugrdh_s_, :Float32), (:cutest_ugrdh_, :Float64))
+for (cutest_ugrdh, T) in ((:cutest_ugrdh_s_, :Float32), (:cutest_ugrdh_, :Float64), (:cutest_ugrdh_q_, :Float128))
   @eval begin
     function ugrdh(
       ::Type{$T},
@@ -1265,7 +1265,7 @@ Usage:
 """
 function ugrsh end
 
-for (cutest_ugrsh, T) in ((:cutest_ugrsh_s_, :Float32), (:cutest_ugrsh_, :Float64))
+for (cutest_ugrsh, T) in ((:cutest_ugrsh_s_, :Float32), (:cutest_ugrsh_, :Float64), (:cutest_ugrsh_q_, :Float128))
   @eval begin
     function ugrsh(
       ::Type{$T},
@@ -1320,7 +1320,7 @@ lhe_val, he_val, byrows)
 """
 function ugreh end
 
-for (cutest_cint_ugreh, T) in ((:cutest_cint_ugreh_s_, :Float32), (:cutest_cint_ugreh_, :Float64))
+for (cutest_cint_ugreh, T) in ((:cutest_cint_ugreh_s_, :Float32), (:cutest_cint_ugreh_, :Float64), (:cutest_cint_ugreh_q_, :Float128))
   @eval begin
     function ugreh(
       ::Type{$T},
@@ -1383,7 +1383,7 @@ Usage:
 function uhprod end
 
 for (cutest_cint_uhprod, T) in
-    ((:cutest_cint_uhprod_s_, :Float32), (:cutest_cint_uhprod_, :Float64))
+    ((:cutest_cint_uhprod_s_, :Float32), (:cutest_cint_uhprod_, :Float64), (:cutest_cint_uhprod_q_, :Float128))
   @eval begin
     function uhprod(
       ::Type{$T},
@@ -1432,7 +1432,7 @@ Notice that `vector` and `result` should have allocated dimension of `n`.
 function ushprod end
 
 for (cutest_cint_ushprod, T) in
-    ((:cutest_cint_ushprod_s_, :Float32), (:cutest_cint_ushprod_, :Float64))
+    ((:cutest_cint_ushprod_s_, :Float32), (:cutest_cint_ushprod_, :Float64), (:cutest_cint_ushprod_q_, :Float128))
   @eval begin
     function ushprod(
       ::Type{$T},
@@ -1490,7 +1490,7 @@ Usage:
 """
 function ubandh end
 
-for (cutest_ubandh, T) in ((:cutest_ubandh_s_, :Float32), (:cutest_ubandh_, :Float64))
+for (cutest_ubandh, T) in ((:cutest_ubandh_s_, :Float32), (:cutest_ubandh_, :Float64), (:cutest_ubandh_q_, :Float128))
   @eval begin
     function ubandh(
       ::Type{$T},
@@ -1534,7 +1534,7 @@ Usage:
 """
 function cfn end
 
-for (cutest_cfn, T) in ((:cutest_cfn_s_, :Float32), (:cutest_cfn_, :Float64))
+for (cutest_cfn, T) in ((:cutest_cfn_s_, :Float32), (:cutest_cfn_, :Float64), (:cutest_cfn_q_, :Float128))
   @eval begin
     function cfn(
       ::Type{$T},
@@ -1577,7 +1577,7 @@ Usage:
 """
 function cofg end
 
-for (cutest_cint_cofg, T) in ((:cutest_cint_cofg_s_, :Float32), (:cutest_cint_cofg_, :Float64))
+for (cutest_cint_cofg, T) in ((:cutest_cint_cofg_s_, :Float32), (:cutest_cint_cofg_, :Float64), (:cutest_cint_cofg_q_, :Float128))
   @eval begin
     function cofg(
       ::Type{$T},
@@ -1623,7 +1623,7 @@ Usage:
 """
 function cofsg end
 
-for (cutest_cint_cofsg, T) in ((:cutest_cint_cofsg_s_, :Float32), (:cutest_cint_cofsg_, :Float64))
+for (cutest_cint_cofsg, T) in ((:cutest_cint_cofsg_s_, :Float32), (:cutest_cint_cofsg_, :Float64), (:cutest_cint_cofsg_q_, :Float128))
   @eval begin
     function cofsg(
       ::Type{$T},
@@ -1673,7 +1673,7 @@ Usage:
 """
 function ccfg end
 
-for (cutest_cint_ccfg, T) in ((:cutest_cint_ccfg_s_, :Float32), (:cutest_cint_ccfg_, :Float64))
+for (cutest_cint_ccfg, T) in ((:cutest_cint_ccfg_s_, :Float32), (:cutest_cint_ccfg_, :Float64), (:cutest_cint_ccfg_q_, :Float128))
   @eval begin
     function ccfg(
       ::Type{$T},
@@ -1722,7 +1722,7 @@ Usage:
 """
 function clfg end
 
-for (cutest_cint_clfg, T) in ((:cutest_cint_clfg_s_, :Float32), (:cutest_cint_clfg_, :Float64))
+for (cutest_cint_clfg, T) in ((:cutest_cint_clfg_s_, :Float32), (:cutest_cint_clfg_, :Float64), (:cutest_cint_clfg_q_, :Float128))
   @eval begin
     function clfg(
       ::Type{$T},
@@ -1773,7 +1773,7 @@ Usage:
 """
 function cgr end
 
-for (cutest_cint_cgr, T) in ((:cutest_cint_cgr_s_, :Float32), (:cutest_cint_cgr_, :Float64))
+for (cutest_cint_cgr, T) in ((:cutest_cint_cgr_s_, :Float32), (:cutest_cint_cgr_, :Float64), (:cutest_cint_cgr_q_, :Float128))
   @eval begin
     function cgr(
       ::Type{$T},
@@ -1829,7 +1829,7 @@ Usage:
 """
 function csgr end
 
-for (cutest_cint_csgr, T) in ((:cutest_cint_csgr_s_, :Float32), (:cutest_cint_csgr_, :Float64))
+for (cutest_cint_csgr, T) in ((:cutest_cint_csgr_s_, :Float32), (:cutest_cint_csgr_, :Float64), (:cutest_cint_csgr_q_, :Float128))
   @eval begin
     function csgr(
       ::Type{$T},
@@ -1883,7 +1883,7 @@ Usage:
 """
 function ccfsg end
 
-for (cutest_cint_ccfsg, T) in ((:cutest_cint_ccfsg_s_, :Float32), (:cutest_cint_ccfsg_, :Float64))
+for (cutest_cint_ccfsg, T) in ((:cutest_cint_ccfsg_s_, :Float32), (:cutest_cint_ccfsg_, :Float64), (:cutest_cint_ccfsg_q_, :Float128))
   @eval begin
     function ccfsg(
       ::Type{$T},
@@ -1933,7 +1933,7 @@ Usage:
 """
 function ccifg end
 
-for (cutest_cint_ccifg, T) in ((:cutest_cint_ccifg_s_, :Float32), (:cutest_cint_ccifg_, :Float64))
+for (cutest_cint_ccifg, T) in ((:cutest_cint_ccifg_s_, :Float32), (:cutest_cint_ccifg_, :Float64), (:cutest_cint_ccifg_q_, :Float128))
   @eval begin
     function ccifg(
       ::Type{$T},
@@ -1984,7 +1984,7 @@ Usage:
 function ccifsg end
 
 for (cutest_cint_ccifsg, T) in
-    ((:cutest_cint_ccifsg_s_, :Float32), (:cutest_cint_ccifsg_, :Float64))
+    ((:cutest_cint_ccifsg_s_, :Float32), (:cutest_cint_ccifsg_, :Float64), (:cutest_cint_ccifsg_q_, :Float128))
   @eval begin
     function ccifsg(
       ::Type{$T},
@@ -2041,7 +2041,7 @@ Usage:
 """
 function cgrdh end
 
-for (cutest_cint_cgrdh, T) in ((:cutest_cint_cgrdh_s_, :Float32), (:cutest_cint_cgrdh_, :Float64))
+for (cutest_cint_cgrdh, T) in ((:cutest_cint_cgrdh_s_, :Float32), (:cutest_cint_cgrdh_, :Float64), (:cutest_cint_cgrdh_q_, :Float128))
   @eval begin
     function cgrdh(
       ::Type{$T},
@@ -2093,7 +2093,7 @@ Usage:
 """
 function cdh end
 
-for (cutest_cdh, T) in ((:cutest_cdh_s_, :Float32), (:cutest_cdh_, :Float64))
+for (cutest_cdh, T) in ((:cutest_cdh_s_, :Float32), (:cutest_cdh_, :Float64), (:cutest_cdh_q_, :Float128))
   @eval begin
     function cdh(
       ::Type{$T},
@@ -2139,7 +2139,7 @@ Usage:
 """
 function cdhc end
 
-for (cutest_cdhc, T) in ((:cutest_cdhc_s_, :Float32), (:cutest_cdhc_, :Float64))
+for (cutest_cdhc, T) in ((:cutest_cdhc_s_, :Float32), (:cutest_cdhc_, :Float64), (:cutest_cdhc_q_, :Float128))
   @eval begin
     function cdhc(
       ::Type{$T},
@@ -2183,7 +2183,7 @@ Usage:
 """
 function cshp end
 
-for (cutest_cshp, T) in ((:cutest_cshp_s_, :Float32), (:cutest_cshp_, :Float64))
+for (cutest_cshp, T) in ((:cutest_cshp_s_, :Float32), (:cutest_cshp_, :Float64), (:cutest_cshp_q_, :Float128))
   @eval begin
     function cshp(
       ::Type{$T},
@@ -2231,7 +2231,7 @@ Usage:
 """
 function csh end
 
-for (cutest_csh, T) in ((:cutest_csh_s_, :Float32), (:cutest_csh_, :Float64))
+for (cutest_csh, T) in ((:cutest_csh_s_, :Float32), (:cutest_csh_, :Float64), (:cutest_csh_q_, :Float128))
   @eval begin
     function csh(
       ::Type{$T},
@@ -2283,7 +2283,7 @@ Usage:
 """
 function cshc end
 
-for (cutest_cshc, T) in ((:cutest_cshc_s_, :Float32), (:cutest_cshc_, :Float64))
+for (cutest_cshc, T) in ((:cutest_cshc_s_, :Float32), (:cutest_cshc_, :Float64), (:cutest_cshc_q_, :Float128))
   @eval begin
     function cshc(
       ::Type{$T},
@@ -2342,7 +2342,7 @@ he_row, lhe_val, he_val, byrows)
 """
 function ceh end
 
-for (cutest_ceh, T) in ((:cutest_ceh_s_, :Float32), (:cutest_ceh_, :Float64))
+for (cutest_ceh, T) in ((:cutest_ceh_s_, :Float32), (:cutest_ceh_, :Float64), (:cutest_ceh_q_, :Float128))
   @eval begin
     function ceh(
       ::Type{$T},
@@ -2409,7 +2409,7 @@ Usage:
 """
 function cidh end
 
-for (cutest_cidh, T) in ((:cutest_cidh_s_, :Float32), (:cutest_cidh_, :Float64))
+for (cutest_cidh, T) in ((:cutest_cidh_s_, :Float32), (:cutest_cidh_, :Float64), (:cutest_cidh_q_, :Float128))
   @eval begin
     function cidh(
       ::Type{$T},
@@ -2456,7 +2456,7 @@ Usage:
 """
 function cish end
 
-for (cutest_cish, T) in ((:cutest_cish_s_, :Float32), (:cutest_cish_, :Float64))
+for (cutest_cish, T) in ((:cutest_cish_s_, :Float32), (:cutest_cish_, :Float64), (:cutest_cish_q_, :Float128))
   @eval begin
     function cish(
       ::Type{$T},
@@ -2517,7 +2517,7 @@ h_val, h_row, h_col)
 function csgrsh end
 
 for (cutest_cint_csgrsh, T) in
-    ((:cutest_cint_csgrsh_s_, :Float32), (:cutest_cint_csgrsh_, :Float64))
+    ((:cutest_cint_csgrsh_s_, :Float32), (:cutest_cint_csgrsh_, :Float64), (:cutest_cint_csgrsh_q_, :Float128))
   @eval begin
     function csgrsh(
       ::Type{$T},
@@ -2610,7 +2610,7 @@ byrows)
 function csgreh end
 
 for (cutest_cint_csgreh, T) in
-    ((:cutest_cint_csgreh_s_, :Float32), (:cutest_cint_csgreh_, :Float64))
+    ((:cutest_cint_csgreh_s_, :Float32), (:cutest_cint_csgreh_, :Float64), (:cutest_cint_csgreh_q_, :Float128))
   @eval begin
     function csgreh(
       ::Type{$T},
@@ -2692,7 +2692,7 @@ Usage:
 function chprod end
 
 for (cutest_cint_chprod, T) in
-    ((:cutest_cint_chprod_s_, :Float32), (:cutest_cint_chprod_, :Float64))
+    ((:cutest_cint_chprod_s_, :Float32), (:cutest_cint_chprod_, :Float64), (:cutest_cint_chprod_q_, :Float128))
   @eval begin
     function chprod(
       ::Type{$T},
@@ -2747,7 +2747,7 @@ Notice that `vector` and `result` should have allocated dimension of `n`.
 """
 function cshprod end
 
-for (cutest_cshprod, T) in ((:cutest_cshprod_s_, :Float32), (:cutest_cshprod_, :Float64))
+for (cutest_cshprod, T) in ((:cutest_cshprod_s_, :Float32), (:cutest_cshprod_, :Float64), (:cutest_cshprod_q_, :Float128))
   @eval begin
     function cshprod(
       ::Type{$T},
@@ -2813,7 +2813,7 @@ Usage:
 function chcprod end
 
 for (cutest_cint_chcprod, T) in
-    ((:cutest_cint_chcprod_s_, :Float32), (:cutest_cint_chcprod_, :Float64))
+    ((:cutest_cint_chcprod_s_, :Float32), (:cutest_cint_chcprod_, :Float64), (:cutest_cint_chcprod_q_, :Float128))
   @eval begin
     function chcprod(
       ::Type{$T},
@@ -2867,7 +2867,7 @@ nnz_result, index_nz_result, result)
 function cshcprod end
 
 for (cutest_cint_cshcprod, T) in
-    ((:cutest_cint_cshcprod_s_, :Float32), (:cutest_cint_cshcprod_, :Float64))
+    ((:cutest_cint_cshcprod_s_, :Float32), (:cutest_cint_cshcprod_, :Float64), (:cutest_cint_cshcprod_q_, :Float128))
   @eval begin
     function cshcprod(
       ::Type{$T},
@@ -2935,7 +2935,7 @@ Usage:
 function cjprod end
 
 for (cutest_cint_cjprod, T) in
-    ((:cutest_cint_cjprod_s_, :Float32), (:cutest_cint_cjprod_, :Float64))
+    ((:cutest_cint_cjprod_s_, :Float32), (:cutest_cint_cjprod_, :Float64), (:cutest_cint_cjprod_q_, :Float128))
   @eval begin
     function cjprod(
       ::Type{$T},
@@ -2993,7 +2993,7 @@ lvector, nnz_result, index_nz_result, result, lresult)
 function csjprod end
 
 for (cutest_cint_csjprod, T) in
-    ((:cutest_cint_csjprod_s_, :Float32), (:cutest_cint_csjprod_, :Float64))
+    ((:cutest_cint_csjprod_s_, :Float32), (:cutest_cint_csjprod_, :Float64), (:cutest_cint_csjprod_q_, :Float128))
   @eval begin
     function csjprod(
       ::Type{$T},
@@ -3065,7 +3065,7 @@ Usage:
 function cchprods end
 
 for (cutest_cint_cchprods, T) in
-    ((:cutest_cint_cchprods_s_, :Float32), (:cutest_cint_cchprods_, :Float64))
+    ((:cutest_cint_cchprods_s_, :Float32), (:cutest_cint_cchprods_, :Float64), (:cutest_cint_cchprods_q_, :Float128))
   @eval begin
     function cchprods(
       ::Type{$T},
@@ -3103,7 +3103,7 @@ Usage:
 """
 function cchprodsp end
 
-for (cutest_cchprodsp, T) in ((:cutest_cchprodsp_s_, :Float32), (:cutest_cchprodsp_, :Float64))
+for (cutest_cchprodsp, T) in ((:cutest_cchprodsp_s_, :Float32), (:cutest_cchprodsp_, :Float64), (:cutest_cchprodsp_q_, :Float128))
   @eval begin
     function cchprodsp(
       ::Type{$T},
@@ -3134,7 +3134,7 @@ Usage:
 """
 function uterminate end
 
-for (cutest_uterminate, T) in ((:cutest_uterminate_s_, :Float32), (:cutest_uterminate_, :Float64))
+for (cutest_uterminate, T) in ((:cutest_uterminate_s_, :Float32), (:cutest_uterminate_, :Float64), (:cutest_uterminate_q_, :Float128))
   @eval begin
     function uterminate(::Type{$T}, status::StrideOneVector{Cint})
       $cutest_uterminate(status)
@@ -3158,7 +3158,7 @@ Usage:
 """
 function cterminate end
 
-for (cutest_cterminate, T) in ((:cutest_cterminate_s_, :Float32), (:cutest_cterminate_, :Float64))
+for (cutest_cterminate, T) in ((:cutest_cterminate_s_, :Float32), (:cutest_cterminate_, :Float64), (:cutest_cterminate_q_, :Float128))
   @eval begin
     function cterminate(::Type{$T}, status::StrideOneVector{Cint})
       $cutest_cterminate(status)
@@ -3187,7 +3187,7 @@ Usage:
 """
 function cifn end
 
-for (cutest_cifn, T) in ((:cutest_cifn_s_, :Float32), (:cutest_cifn_, :Float64))
+for (cutest_cifn, T) in ((:cutest_cifn_s_, :Float32), (:cutest_cifn_, :Float64), (:cutest_cifn_q_, :Float128))
   @eval begin
     function cifn(
       ::Type{$T},
@@ -3225,7 +3225,7 @@ Usage:
 """
 function cisgr end
 
-for (cutest_cisgr, T) in ((:cutest_cisgr_s_, :Float32), (:cutest_cisgr_, :Float64))
+for (cutest_cisgr, T) in ((:cutest_cisgr_s_, :Float32), (:cutest_cisgr_, :Float64), (:cutest_cisgr_q_, :Float128))
   @eval begin
     function cisgr(
       ::Type{$T},
@@ -3266,7 +3266,7 @@ Usage:
 """
 function csgrp end
 
-for (cutest_csgrp, T) in ((:cutest_csgrp_s_, :Float32), (:cutest_csgrp_, :Float64))
+for (cutest_csgrp, T) in ((:cutest_csgrp_s_, :Float32), (:cutest_csgrp_, :Float64), (:cutest_csgrp_q_, :Float128))
   @eval begin
     function csgrp(
       ::Type{$T},
@@ -3299,7 +3299,7 @@ For more information, run the shell command
 """
 function cigr end
 
-for (cutest_cigr, T) in ((:cutest_cigr_s_, :Float32), (:cutest_cigr_, :Float64))
+for (cutest_cigr, T) in ((:cutest_cigr_s_, :Float32), (:cutest_cigr_, :Float64), (:cutest_cigr_q_, :Float128))
   @eval begin
     function cigr(
       ::Type{$T},
@@ -3338,7 +3338,7 @@ For more information, run the shell command
 """
 function csgrshp end
 
-for (cutest_csgrshp, T) in ((:cutest_csgrshp_s_, :Float32), (:cutest_csgrshp_, :Float64))
+for (cutest_csgrshp, T) in ((:cutest_csgrshp_s_, :Float32), (:cutest_csgrshp_, :Float64), (:cutest_csgrshp_q_, :Float128))
   @eval begin
     function csgrshp(
       ::Type{$T},
@@ -3374,7 +3374,7 @@ For more information, run the shell command
 """
 function csjp end
 
-for (cutest_csjp, T) in ((:cutest_csjp_s_, :Float32), (:cutest_csjp_, :Float64))
+for (cutest_csjp, T) in ((:cutest_csjp_s_, :Float32), (:cutest_csjp_, :Float64), (:cutest_csjp_q_, :Float128))
   @eval begin
     function csjp(
       ::Type{$T},
@@ -3389,7 +3389,7 @@ for (cutest_csjp, T) in ((:cutest_csjp_s_, :Float32), (:cutest_csjp_, :Float64))
   end
 end
 
-for (fortran_open, T) in ((:fortran_open_s_, :Float32), (:fortran_open_, :Float64))
+for (fortran_open, T) in ((:fortran_open_s_, :Float32), (:fortran_open_, :Float64), (:fortran_open_q_, :Float128))
   @eval begin
     function fopen(::Type{$T}, funit, outsdif, status)
       $fortran_open(funit, outsdif, status)
@@ -3397,7 +3397,7 @@ for (fortran_open, T) in ((:fortran_open_s_, :Float32), (:fortran_open_, :Float6
   end
 end
 
-for (fortran_close, T) in ((:fortran_close_s_, :Float32), (:fortran_close_, :Float64))
+for (fortran_close, T) in ((:fortran_close_s_, :Float32), (:fortran_close_, :Float64), (:fortran_close_q_, :Float128))
   @eval begin
     function fclose(::Type{$T}, funit, status)
       $fortran_close(funit, status)
@@ -3405,7 +3405,7 @@ for (fortran_close, T) in ((:fortran_close_s_, :Float32), (:fortran_close_, :Flo
   end
 end
 
-for (cutest_cconst, T) in ((:cutest_cconst_s_, :Float32), (:cutest_cconst_, :Float64))
+for (cutest_cconst, T) in ((:cutest_cconst_s_, :Float32), (:cutest_cconst_, :Float64), (:cutest_cconst_q_, :Float128))
   @eval begin
     function cconst(::Type{$T}, status, m, c)
       $cutest_cconst(status, m, c)

--- a/src/libcutest.jl
+++ b/src/libcutest.jl
@@ -1109,6 +1109,24 @@ function fortran_close_s_(funit, ierr)
   @ccall $ptr_fortran_close_s_(funit::Ptr{Cint}, ierr::Ptr{Cint})::Cvoid
 end
 
+function cutest_usetup_q_(status, funit, iout, io_buffer, n, x, bl, bu)
+  ptr_cutest_usetup_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_usetup_q_)
+  @ccall $ptr_cutest_usetup_q_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
+                               io_buffer::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
+                               bl::Ptr{Cfloat128}, bu::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_csetup_q_(status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu, equatn,
+                               linear, e_order, l_order, v_order)
+  ptr_cutest_cint_csetup_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csetup_q_)
+  @ccall $ptr_cutest_cint_csetup_q_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
+                                    io_buffer::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
+                                    x::Ptr{Cfloat128}, bl::Ptr{Cfloat128}, bu::Ptr{Cfloat128},
+                                    v::Ptr{Cfloat128}, cl::Ptr{Cfloat128}, cu::Ptr{Cfloat128},
+                                    equatn::Ptr{Bool}, linear::Ptr{Bool}, e_order::Ptr{Cint},
+                                    l_order::Ptr{Cint}, v_order::Ptr{Cint})::Cvoid
+end
+
 function cutest_udimen_q_(status, funit, n)
   ptr_cutest_udimen_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udimen_q_)
   @ccall $ptr_cutest_udimen_q_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint})::Cvoid
@@ -1134,6 +1152,11 @@ function cutest_unames_q_(status, n, pname, vnames)
   ptr_cutest_unames_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_unames_q_)
   @ccall $ptr_cutest_unames_q_(status::Ptr{Cint}, n::Ptr{Cint}, pname::Ptr{Cchar},
                                vnames::Ptr{Cchar})::Cvoid
+end
+
+function cutest_ureport_q_(status, calls, time)
+  ptr_cutest_ureport_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ureport_q_)
+  @ccall $ptr_cutest_ureport_q_(status::Ptr{Cint}, calls::Ptr{Cfloat128}, time::Ptr{Cfloat128})::Cvoid
 end
 
 function cutest_cdimen_q_(status, funit, n, m)
@@ -1198,6 +1221,11 @@ function cutest_cnames_q_(status, n, m, pname, vnames, gnames)
                                vnames::Ptr{Cchar}, gnames::Ptr{Cchar})::Cvoid
 end
 
+function cutest_creport_q_(status, calls, time)
+  ptr_cutest_creport_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_creport_q_)
+  @ccall $ptr_cutest_creport_q_(status::Ptr{Cint}, calls::Ptr{Cfloat128}, time::Ptr{Cfloat128})::Cvoid
+end
+
 function cutest_connames_q_(status, m, gname)
   ptr_cutest_connames_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_connames_q_)
   @ccall $ptr_cutest_connames_q_(status::Ptr{Cint}, m::Ptr{Cint}, gname::Ptr{Cchar})::Cvoid
@@ -1218,10 +1246,144 @@ function cutest_varnames_q_(status, n, vname)
   @ccall $ptr_cutest_varnames_q_(status::Ptr{Cint}, n::Ptr{Cint}, vname::Ptr{Cchar})::Cvoid
 end
 
+function cutest_ufn_q_(status, n, x, f)
+  ptr_cutest_ufn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ufn_q_)
+  @ccall $ptr_cutest_ufn_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
+                            f::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_ugr_q_(status, n, x, g)
+  ptr_cutest_ugr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugr_q_)
+  @ccall $ptr_cutest_ugr_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
+                            g::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_uofg_q_(status, n, x, f, g, grad)
+  ptr_cutest_cint_uofg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_uofg_q_)
+  @ccall $ptr_cutest_cint_uofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, f::Ptr{Cfloat128},
+                                  g::Ptr{Cfloat128}, grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_udh_q_(status, n, x, lh1, h)
+  ptr_cutest_udh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udh_q_)
+  @ccall $ptr_cutest_udh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, lh1::Ptr{Cint},
+                            h::Ptr{Cfloat128})::Cvoid
+end
+
 function cutest_ushp_q_(status, n, nnzh, lh, irnh, icnh)
   ptr_cutest_ushp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ushp_q_)
   @ccall $ptr_cutest_ushp_q_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_ush_q_(status, n, x, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ush_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ush_q_)
+  @ccall $ptr_cutest_ush_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, nnzh::Ptr{Cint},
+                            lh::Ptr{Cint}, h::Ptr{Cfloat128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_ueh_q_(status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
+  ptr_cutest_cint_ueh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ueh_q_)
+  @ccall $ptr_cutest_cint_ueh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, ne::Ptr{Cint},
+                                 le::Ptr{Cint}, iprnhi::Ptr{Cint}, iprhi::Ptr{Cint},
+                                 lirnhi::Ptr{Cint}, irnhi::Ptr{Cint}, lhi::Ptr{Cint},
+                                 hi::Ptr{Cfloat128}, byrows::Ptr{Bool})::Cvoid
+end
+
+function cutest_ugrdh_q_(status, n, x, g, lh1, h)
+  ptr_cutest_ugrdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugrdh_q_)
+  @ccall $ptr_cutest_ugrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, g::Ptr{Cfloat128},
+                              lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_ugrsh_q_(status, n, x, g, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ugrsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugrsh_q_)
+  @ccall $ptr_cutest_ugrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, g::Ptr{Cfloat128},
+                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128}, irnh::Ptr{Cint},
+                              icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_ugreh_q_(status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                              byrows)
+  ptr_cutest_cint_ugreh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ugreh_q_)
+  @ccall $ptr_cutest_cint_ugreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
+                                   g::Ptr{Cfloat128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
+                                   iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
+                                   lhi::Ptr{Cint}, hi::Ptr{Cfloat128}, byrows::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_uhprod_q_(status, n, goth, x, p, r)
+  ptr_cutest_cint_uhprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_uhprod_q_)
+  @ccall $ptr_cutest_cint_uhprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
+                                    x::Ptr{Cfloat128}, p::Ptr{Cfloat128}, r::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_ushprod_q_(status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_ushprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ushprod_q_)
+  @ccall $ptr_cutest_cint_ushprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
+                                     x::Ptr{Cfloat128}, nnzp::Ptr{Cint}, indp::Ptr{Cint},
+                                     p::Ptr{Cfloat128}, nnzr::Ptr{Cint}, indr::Ptr{Cint},
+                                     r::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_ubandh_q_(status, n, x, nsemib, bandh, lbandh, maxsbw)
+  ptr_cutest_ubandh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ubandh_q_)
+  @ccall $ptr_cutest_ubandh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, nsemib::Ptr{Cint},
+                               bandh::Ptr{Cfloat128}, lbandh::Ptr{Cint}, maxsbw::Ptr{Cint})::Cvoid
+end
+
+function cutest_cfn_q_(status, n, m, x, f, c)
+  ptr_cutest_cfn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cfn_q_)
+  @ccall $ptr_cutest_cfn_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                            f::Ptr{Cfloat128}, c::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cconst_q_(status, m, c)
+  ptr_cutest_cconst_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cconst_q_)
+  @ccall $ptr_cutest_cconst_q_(status::Ptr{Cint}, m::Ptr{Cint}, c::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_cofg_q_(status, n, x, f, g, grad)
+  ptr_cutest_cint_cofg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cofg_q_)
+  @ccall $ptr_cutest_cint_cofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, f::Ptr{Cfloat128},
+                                  g::Ptr{Cfloat128}, grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_cofsg_q_(status, n, x, f, nnzg, lg, sg, ivsg, grad)
+  ptr_cutest_cint_cofsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cofsg_q_)
+  @ccall $ptr_cutest_cint_cofsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
+                                   f::Ptr{Cfloat128}, nnzg::Ptr{Cint}, lg::Ptr{Cint},
+                                   sg::Ptr{Cfloat128}, ivsg::Ptr{Cint}, grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_ccfg_q_(status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+  ptr_cutest_cint_ccfg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccfg_q_)
+  @ccall $ptr_cutest_cint_ccfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                  c::Ptr{Cfloat128}, jtrans::Ptr{Bool}, lcjac1::Ptr{Cint},
+                                  lcjac2::Ptr{Cint}, cjac::Ptr{Cfloat128}, grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_clfg_q_(status, n, m, x, y, f, g, grad)
+  ptr_cutest_cint_clfg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_clfg_q_)
+  @ccall $ptr_cutest_cint_clfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                  y::Ptr{Cfloat128}, f::Ptr{Cfloat128}, g::Ptr{Cfloat128},
+                                  grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_cgr_q_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
+  ptr_cutest_cint_cgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cgr_q_)
+  @ccall $ptr_cutest_cint_cgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                 y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, g::Ptr{Cfloat128},
+                                 jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
+                                 cjac::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_csgr_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
+  ptr_cutest_cint_csgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgr_q_)
+  @ccall $ptr_cutest_cint_csgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                  y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
+                                  lcjac::Ptr{Cint}, cjac::Ptr{Cfloat128}, indvar::Ptr{Cint},
+                                  indfun::Ptr{Cint})::Cvoid
 end
 
 function cutest_csgrp_q_(status, n, nnzj, lj, jvar, jcon)
@@ -1236,16 +1398,138 @@ function cutest_csjp_q_(status, nnzj, lj, jvar, jcon)
                              jcon::Ptr{Cint})::Cvoid
 end
 
+function cutest_cint_ccfsg_q_(status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
+  ptr_cutest_cint_ccfsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccfsg_q_)
+  @ccall $ptr_cutest_cint_ccfsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                   c::Ptr{Cfloat128}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
+                                   cjac::Ptr{Cfloat128}, indvar::Ptr{Cint}, indfun::Ptr{Cint},
+                                   grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_ccifg_q_(status, n, icon, x, ci, gci, grad)
+  ptr_cutest_cint_ccifg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccifg_q_)
+  @ccall $ptr_cutest_cint_ccifg_q_(status::Ptr{Cint}, n::Ptr{Cint}, icon::Ptr{Cint},
+                                   x::Ptr{Cfloat128}, ci::Ptr{Cfloat128}, gci::Ptr{Cfloat128},
+                                   grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_ccifsg_q_(status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
+  ptr_cutest_cint_ccifsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccifsg_q_)
+  @ccall $ptr_cutest_cint_ccifsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, con::Ptr{Cint},
+                                    x::Ptr{Cfloat128}, ci::Ptr{Cfloat128}, nnzsgc::Ptr{Cint},
+                                    lsgci::Ptr{Cint}, sgci::Ptr{Cfloat128}, ivsgci::Ptr{Cint},
+                                    grad::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_cgrdh_q_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac, lh1, h)
+  ptr_cutest_cint_cgrdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cgrdh_q_)
+  @ccall $ptr_cutest_cint_cgrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                   y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, g::Ptr{Cfloat128},
+                                   jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
+                                   cjac::Ptr{Cfloat128}, lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cdh_q_(status, n, m, x, y, lh1, h)
+  ptr_cutest_cdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdh_q_)
+  @ccall $ptr_cutest_cdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                            y::Ptr{Cfloat128}, lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cdhc_q_(status, n, m, x, y, lh1, h)
+  ptr_cutest_cdhc_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdhc_q_)
+  @ccall $ptr_cutest_cdhc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                             y::Ptr{Cfloat128}, lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cdhj_q_(status, n, m, x, y0, y, lh1, h)
+  ptr_cutest_cdhj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdhj_q_)
+  @ccall $ptr_cutest_cdhj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                             y0::Ptr{Cfloat128}, y::Ptr{Cfloat128}, lh1::Ptr{Cint},
+                             h::Ptr{Cfloat128})::Cvoid
+end
+
 function cutest_cshp_q_(status, n, nnzh, lh, irnh, icnh)
   ptr_cutest_cshp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshp_q_)
   @ccall $ptr_cutest_cshp_q_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
+function cutest_csh_q_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_csh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_csh_q_)
+  @ccall $ptr_cutest_csh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                            y::Ptr{Cfloat128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128},
+                            irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cshc_q_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshc_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshc_q_)
+  @ccall $ptr_cutest_cshc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                             y::Ptr{Cfloat128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128},
+                             irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cshj_q_(status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshj_q_)
+  @ccall $ptr_cutest_cshj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                             y0::Ptr{Cfloat128}, y::Ptr{Cfloat128}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
+                             h::Ptr{Cfloat128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_ceh_q_(status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                            byrows)
+  ptr_cutest_cint_ceh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ceh_q_)
+  @ccall $ptr_cutest_cint_ceh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                 y::Ptr{Cfloat128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
+                                 iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
+                                 lhi::Ptr{Cint}, hi::Ptr{Cfloat128}, byrows::Ptr{Bool})::Cvoid
+end
+
+function cutest_cifn_q_(status, n, iprob, x, f)
+  ptr_cutest_cifn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cifn_q_)
+  @ccall $ptr_cutest_cifn_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Cfloat128},
+                             f::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cigr_q_(status, n, iprob, x, g)
+  ptr_cutest_cigr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cigr_q_)
+  @ccall $ptr_cutest_cigr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Cfloat128},
+                             g::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cisgr_q_(status, n, iprob, x, nnzg, lg, sg, ivsg)
+  ptr_cutest_cisgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cisgr_q_)
+  @ccall $ptr_cutest_cisgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Cfloat128},
+                              nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Cfloat128},
+                              ivsg::Ptr{Cint})::Cvoid
+end
+
 function cutest_cisgrp_q_(status, n, iprob, nnzg, lg, ivsg)
   ptr_cutest_cisgrp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cisgrp_q_)
   @ccall $ptr_cutest_cisgrp_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzg::Ptr{Cint},
                                lg::Ptr{Cint}, ivsg::Ptr{Cint})::Cvoid
+end
+
+function cutest_cidh_q_(status, n, x, iprob, lh1, h)
+  ptr_cutest_cidh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cidh_q_)
+  @ccall $ptr_cutest_cidh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, iprob::Ptr{Cint},
+                             lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cish_q_(status, n, x, iprob, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cish_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cish_q_)
+  @ccall $ptr_cutest_cish_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, iprob::Ptr{Cint},
+                             nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128}, irnh::Ptr{Cint},
+                             icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_csgrsh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, nnzh,
+                               lh, h, irnh, icnh)
+  ptr_cutest_cint_csgrsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgrsh_q_)
+  @ccall $ptr_cutest_cint_csgrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                    y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
+                                    lcjac::Ptr{Cint}, cjac::Ptr{Cfloat128}, indvar::Ptr{Cint},
+                                    indfun::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
+                                    h::Ptr{Cfloat128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_csgrshp_q_(status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
@@ -1255,10 +1539,91 @@ function cutest_csgrshp_q_(status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irn
                                 lh::Ptr{Cint}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
+function cutest_cint_csgreh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, ne,
+                               le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
+  ptr_cutest_cint_csgreh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgreh_q_)
+  @ccall $ptr_cutest_cint_csgreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
+                                    y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
+                                    lcjac::Ptr{Cint}, cjac::Ptr{Cfloat128}, indvar::Ptr{Cint},
+                                    indfun::Ptr{Cint}, ne::Ptr{Cint}, le::Ptr{Cint},
+                                    iprnhi::Ptr{Cint}, iprhi::Ptr{Cint}, lirnhi::Ptr{Cint},
+                                    irnhi::Ptr{Cint}, lhi::Ptr{Cint}, hi::Ptr{Cfloat128},
+                                    byrows::Ptr{Bool})::Cvoid
+end
+
+function cutest_cint_chprod_q_(status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chprod_q_)
+  @ccall $ptr_cutest_cint_chprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
+                                    x::Ptr{Cfloat128}, y::Ptr{Cfloat128}, p::Ptr{Cfloat128},
+                                    q::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_chsprod_q_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_chsprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chsprod_q_)
+  @ccall $ptr_cutest_cint_chsprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
+                                     x::Ptr{Cfloat128}, y::Ptr{Cfloat128}, nnzp::Ptr{Cint},
+                                     indp::Ptr{Cint}, p::Ptr{Cfloat128}, nnzr::Ptr{Cint},
+                                     indr::Ptr{Cint}, r::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_chcprod_q_(status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chcprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chcprod_q_)
+  @ccall $ptr_cutest_cint_chcprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
+                                     x::Ptr{Cfloat128}, y::Ptr{Cfloat128}, p::Ptr{Cfloat128},
+                                     q::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_cshcprod_q_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_cshcprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cshcprod_q_)
+  @ccall $ptr_cutest_cint_cshcprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
+                                      goth::Ptr{Bool}, x::Ptr{Cfloat128}, y::Ptr{Cfloat128},
+                                      nnzp::Ptr{Cint}, indp::Ptr{Cint}, p::Ptr{Cfloat128},
+                                      nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_chjprod_q_(status, n, m, goth, x, y0, y, p, q)
+  ptr_cutest_cint_chjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chjprod_q_)
+  @ccall $ptr_cutest_cint_chjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
+                                     x::Ptr{Cfloat128}, y0::Ptr{Cfloat128}, y::Ptr{Cfloat128},
+                                     p::Ptr{Cfloat128}, q::Ptr{Cfloat128})::Cvoid
+end
+
+function cutest_cint_cjprod_q_(status, n, m, gotj, jtrans, x, p, lp, r, lr)
+  ptr_cutest_cint_cjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cjprod_q_)
+  @ccall $ptr_cutest_cint_cjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
+                                    jtrans::Ptr{Bool}, x::Ptr{Cfloat128}, p::Ptr{Cfloat128},
+                                    lp::Ptr{Cint}, r::Ptr{Cfloat128}, lr::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_csjprod_q_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr, indr, r, lr)
+  ptr_cutest_cint_csjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csjprod_q_)
+  @ccall $ptr_cutest_cint_csjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
+                                     jtrans::Ptr{Bool}, x::Ptr{Cfloat128}, nnzp::Ptr{Cint},
+                                     indp::Ptr{Cint}, p::Ptr{Cfloat128}, lp::Ptr{Cint},
+                                     nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Cfloat128},
+                                     lr::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_cchprods_q_(status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
+  ptr_cutest_cint_cchprods_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cchprods_q_)
+  @ccall $ptr_cutest_cint_cchprods_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
+                                      goth::Ptr{Bool}, x::Ptr{Cfloat128}, p::Ptr{Cfloat128},
+                                      lchp::Ptr{Cint}, chpval::Ptr{Cfloat128}, chpind::Ptr{Cint},
+                                      chpptr::Ptr{Cint})::Cvoid
+end
+
 function cutest_cchprodsp_q_(status, m, lchp, chpind, chpptr)
   ptr_cutest_cchprodsp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cchprodsp_q_)
   @ccall $ptr_cutest_cchprodsp_q_(status::Ptr{Cint}, m::Ptr{Cint}, lchp::Ptr{Cint},
                                   chpind::Ptr{Cint}, chpptr::Ptr{Cint})::Cvoid
+end
+
+function cutest_cint_cohprods_q_(status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
+  ptr_cutest_cint_cohprods_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cohprods_q_)
+  @ccall $ptr_cutest_cint_cohprods_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
+                                      x::Ptr{Cfloat128}, p::Ptr{Cfloat128}, nnzohp::Ptr{Cint},
+                                      lohp::Ptr{Cint}, ohpval::Ptr{Cfloat128},
+                                      ohpind::Ptr{Cint})::Cvoid
 end
 
 function cutest_cohprodsp_q_(status, nnzohp, lohp, chpind)

--- a/src/libcutest.jl
+++ b/src/libcutest.jl
@@ -1112,8 +1112,8 @@ end
 function cutest_usetup_q_(status, funit, iout, io_buffer, n, x, bl, bu)
   ptr_cutest_usetup_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_usetup_q_)
   @ccall $ptr_cutest_usetup_q_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
-                               io_buffer::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
-                               bl::Ptr{Cfloat128}, bu::Ptr{Cfloat128})::Cvoid
+                               io_buffer::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
+                               bl::Ptr{Float128}, bu::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_csetup_q_(status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu, equatn,
@@ -1121,8 +1121,8 @@ function cutest_cint_csetup_q_(status, funit, iout, io_buffer, n, m, x, bl, bu, 
   ptr_cutest_cint_csetup_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csetup_q_)
   @ccall $ptr_cutest_cint_csetup_q_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                                     io_buffer::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
-                                    x::Ptr{Cfloat128}, bl::Ptr{Cfloat128}, bu::Ptr{Cfloat128},
-                                    v::Ptr{Cfloat128}, cl::Ptr{Cfloat128}, cu::Ptr{Cfloat128},
+                                    x::Ptr{Float128}, bl::Ptr{Float128}, bu::Ptr{Float128},
+                                    v::Ptr{Float128}, cl::Ptr{Float128}, cu::Ptr{Float128},
                                     equatn::Ptr{Bool}, linear::Ptr{Bool}, e_order::Ptr{Cint},
                                     l_order::Ptr{Cint}, v_order::Ptr{Cint})::Cvoid
 end
@@ -1156,7 +1156,7 @@ end
 
 function cutest_ureport_q_(status, calls, time)
   ptr_cutest_ureport_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ureport_q_)
-  @ccall $ptr_cutest_ureport_q_(status::Ptr{Cint}, calls::Ptr{Cfloat128}, time::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_ureport_q_(status::Ptr{Cint}, calls::Ptr{Float128}, time::Ptr{Float128})::Cvoid
 end
 
 function cutest_cdimen_q_(status, funit, n, m)
@@ -1223,7 +1223,7 @@ end
 
 function cutest_creport_q_(status, calls, time)
   ptr_cutest_creport_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_creport_q_)
-  @ccall $ptr_cutest_creport_q_(status::Ptr{Cint}, calls::Ptr{Cfloat128}, time::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_creport_q_(status::Ptr{Cint}, calls::Ptr{Float128}, time::Ptr{Float128})::Cvoid
 end
 
 function cutest_connames_q_(status, m, gname)
@@ -1248,26 +1248,26 @@ end
 
 function cutest_ufn_q_(status, n, x, f)
   ptr_cutest_ufn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ufn_q_)
-  @ccall $ptr_cutest_ufn_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
-                            f::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_ufn_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
+                            f::Ptr{Float128})::Cvoid
 end
 
 function cutest_ugr_q_(status, n, x, g)
   ptr_cutest_ugr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugr_q_)
-  @ccall $ptr_cutest_ugr_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
-                            g::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_ugr_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
+                            g::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_uofg_q_(status, n, x, f, g, grad)
   ptr_cutest_cint_uofg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_uofg_q_)
-  @ccall $ptr_cutest_cint_uofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, f::Ptr{Cfloat128},
-                                  g::Ptr{Cfloat128}, grad::Ptr{Bool})::Cvoid
+  @ccall $ptr_cutest_cint_uofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, f::Ptr{Float128},
+                                  g::Ptr{Float128}, grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_udh_q_(status, n, x, lh1, h)
   ptr_cutest_udh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udh_q_)
-  @ccall $ptr_cutest_udh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, lh1::Ptr{Cint},
-                            h::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_udh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, lh1::Ptr{Cint},
+                            h::Ptr{Float128})::Cvoid
 end
 
 function cutest_ushp_q_(status, n, nnzh, lh, irnh, icnh)
@@ -1278,111 +1278,111 @@ end
 
 function cutest_ush_q_(status, n, x, nnzh, lh, h, irnh, icnh)
   ptr_cutest_ush_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ush_q_)
-  @ccall $ptr_cutest_ush_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, nnzh::Ptr{Cint},
-                            lh::Ptr{Cint}, h::Ptr{Cfloat128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+  @ccall $ptr_cutest_ush_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, nnzh::Ptr{Cint},
+                            lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_ueh_q_(status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
   ptr_cutest_cint_ueh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ueh_q_)
-  @ccall $ptr_cutest_cint_ueh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, ne::Ptr{Cint},
+  @ccall $ptr_cutest_cint_ueh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, ne::Ptr{Cint},
                                  le::Ptr{Cint}, iprnhi::Ptr{Cint}, iprhi::Ptr{Cint},
                                  lirnhi::Ptr{Cint}, irnhi::Ptr{Cint}, lhi::Ptr{Cint},
-                                 hi::Ptr{Cfloat128}, byrows::Ptr{Bool})::Cvoid
+                                 hi::Ptr{Float128}, byrows::Ptr{Bool})::Cvoid
 end
 
 function cutest_ugrdh_q_(status, n, x, g, lh1, h)
   ptr_cutest_ugrdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugrdh_q_)
-  @ccall $ptr_cutest_ugrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, g::Ptr{Cfloat128},
-                              lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_ugrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, g::Ptr{Float128},
+                              lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
 function cutest_ugrsh_q_(status, n, x, g, nnzh, lh, h, irnh, icnh)
   ptr_cutest_ugrsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugrsh_q_)
-  @ccall $ptr_cutest_ugrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, g::Ptr{Cfloat128},
-                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128}, irnh::Ptr{Cint},
+  @ccall $ptr_cutest_ugrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, g::Ptr{Float128},
+                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint},
                               icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_ugreh_q_(status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
                               byrows)
   ptr_cutest_cint_ugreh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ugreh_q_)
-  @ccall $ptr_cutest_cint_ugreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
-                                   g::Ptr{Cfloat128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
+  @ccall $ptr_cutest_cint_ugreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
+                                   g::Ptr{Float128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                    iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
-                                   lhi::Ptr{Cint}, hi::Ptr{Cfloat128}, byrows::Ptr{Bool})::Cvoid
+                                   lhi::Ptr{Cint}, hi::Ptr{Float128}, byrows::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_uhprod_q_(status, n, goth, x, p, r)
   ptr_cutest_cint_uhprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_uhprod_q_)
   @ccall $ptr_cutest_cint_uhprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
-                                    x::Ptr{Cfloat128}, p::Ptr{Cfloat128}, r::Ptr{Cfloat128})::Cvoid
+                                    x::Ptr{Float128}, p::Ptr{Float128}, r::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_ushprod_q_(status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
   ptr_cutest_cint_ushprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ushprod_q_)
   @ccall $ptr_cutest_cint_ushprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
-                                     x::Ptr{Cfloat128}, nnzp::Ptr{Cint}, indp::Ptr{Cint},
-                                     p::Ptr{Cfloat128}, nnzr::Ptr{Cint}, indr::Ptr{Cint},
-                                     r::Ptr{Cfloat128})::Cvoid
+                                     x::Ptr{Float128}, nnzp::Ptr{Cint}, indp::Ptr{Cint},
+                                     p::Ptr{Float128}, nnzr::Ptr{Cint}, indr::Ptr{Cint},
+                                     r::Ptr{Float128})::Cvoid
 end
 
 function cutest_ubandh_q_(status, n, x, nsemib, bandh, lbandh, maxsbw)
   ptr_cutest_ubandh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ubandh_q_)
-  @ccall $ptr_cutest_ubandh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, nsemib::Ptr{Cint},
-                               bandh::Ptr{Cfloat128}, lbandh::Ptr{Cint}, maxsbw::Ptr{Cint})::Cvoid
+  @ccall $ptr_cutest_ubandh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, nsemib::Ptr{Cint},
+                               bandh::Ptr{Float128}, lbandh::Ptr{Cint}, maxsbw::Ptr{Cint})::Cvoid
 end
 
 function cutest_cfn_q_(status, n, m, x, f, c)
   ptr_cutest_cfn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cfn_q_)
-  @ccall $ptr_cutest_cfn_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                            f::Ptr{Cfloat128}, c::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cfn_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                            f::Ptr{Float128}, c::Ptr{Float128})::Cvoid
 end
 
 function cutest_cconst_q_(status, m, c)
   ptr_cutest_cconst_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cconst_q_)
-  @ccall $ptr_cutest_cconst_q_(status::Ptr{Cint}, m::Ptr{Cint}, c::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cconst_q_(status::Ptr{Cint}, m::Ptr{Cint}, c::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_cofg_q_(status, n, x, f, g, grad)
   ptr_cutest_cint_cofg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cofg_q_)
-  @ccall $ptr_cutest_cint_cofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, f::Ptr{Cfloat128},
-                                  g::Ptr{Cfloat128}, grad::Ptr{Bool})::Cvoid
+  @ccall $ptr_cutest_cint_cofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, f::Ptr{Float128},
+                                  g::Ptr{Float128}, grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_cofsg_q_(status, n, x, f, nnzg, lg, sg, ivsg, grad)
   ptr_cutest_cint_cofsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cofsg_q_)
-  @ccall $ptr_cutest_cint_cofsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128},
-                                   f::Ptr{Cfloat128}, nnzg::Ptr{Cint}, lg::Ptr{Cint},
-                                   sg::Ptr{Cfloat128}, ivsg::Ptr{Cint}, grad::Ptr{Bool})::Cvoid
+  @ccall $ptr_cutest_cint_cofsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
+                                   f::Ptr{Float128}, nnzg::Ptr{Cint}, lg::Ptr{Cint},
+                                   sg::Ptr{Float128}, ivsg::Ptr{Cint}, grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_ccfg_q_(status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
   ptr_cutest_cint_ccfg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccfg_q_)
-  @ccall $ptr_cutest_cint_ccfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                  c::Ptr{Cfloat128}, jtrans::Ptr{Bool}, lcjac1::Ptr{Cint},
-                                  lcjac2::Ptr{Cint}, cjac::Ptr{Cfloat128}, grad::Ptr{Bool})::Cvoid
+  @ccall $ptr_cutest_cint_ccfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                  c::Ptr{Float128}, jtrans::Ptr{Bool}, lcjac1::Ptr{Cint},
+                                  lcjac2::Ptr{Cint}, cjac::Ptr{Float128}, grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_clfg_q_(status, n, m, x, y, f, g, grad)
   ptr_cutest_cint_clfg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_clfg_q_)
-  @ccall $ptr_cutest_cint_clfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                  y::Ptr{Cfloat128}, f::Ptr{Cfloat128}, g::Ptr{Cfloat128},
+  @ccall $ptr_cutest_cint_clfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                  y::Ptr{Float128}, f::Ptr{Float128}, g::Ptr{Float128},
                                   grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_cgr_q_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
   ptr_cutest_cint_cgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cgr_q_)
-  @ccall $ptr_cutest_cint_cgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                 y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, g::Ptr{Cfloat128},
+  @ccall $ptr_cutest_cint_cgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                 y::Ptr{Float128}, grlagf::Ptr{Bool}, g::Ptr{Float128},
                                  jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
-                                 cjac::Ptr{Cfloat128})::Cvoid
+                                 cjac::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_csgr_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
   ptr_cutest_cint_csgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgr_q_)
-  @ccall $ptr_cutest_cint_csgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                  y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
-                                  lcjac::Ptr{Cint}, cjac::Ptr{Cfloat128}, indvar::Ptr{Cint},
+  @ccall $ptr_cutest_cint_csgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                  y::Ptr{Float128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
+                                  lcjac::Ptr{Cint}, cjac::Ptr{Float128}, indvar::Ptr{Cint},
                                   indfun::Ptr{Cint})::Cvoid
 end
 
@@ -1400,52 +1400,52 @@ end
 
 function cutest_cint_ccfsg_q_(status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
   ptr_cutest_cint_ccfsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccfsg_q_)
-  @ccall $ptr_cutest_cint_ccfsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                   c::Ptr{Cfloat128}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
-                                   cjac::Ptr{Cfloat128}, indvar::Ptr{Cint}, indfun::Ptr{Cint},
+  @ccall $ptr_cutest_cint_ccfsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                   c::Ptr{Float128}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
+                                   cjac::Ptr{Float128}, indvar::Ptr{Cint}, indfun::Ptr{Cint},
                                    grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_ccifg_q_(status, n, icon, x, ci, gci, grad)
   ptr_cutest_cint_ccifg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccifg_q_)
   @ccall $ptr_cutest_cint_ccifg_q_(status::Ptr{Cint}, n::Ptr{Cint}, icon::Ptr{Cint},
-                                   x::Ptr{Cfloat128}, ci::Ptr{Cfloat128}, gci::Ptr{Cfloat128},
+                                   x::Ptr{Float128}, ci::Ptr{Float128}, gci::Ptr{Float128},
                                    grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_ccifsg_q_(status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
   ptr_cutest_cint_ccifsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccifsg_q_)
   @ccall $ptr_cutest_cint_ccifsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, con::Ptr{Cint},
-                                    x::Ptr{Cfloat128}, ci::Ptr{Cfloat128}, nnzsgc::Ptr{Cint},
-                                    lsgci::Ptr{Cint}, sgci::Ptr{Cfloat128}, ivsgci::Ptr{Cint},
+                                    x::Ptr{Float128}, ci::Ptr{Float128}, nnzsgc::Ptr{Cint},
+                                    lsgci::Ptr{Cint}, sgci::Ptr{Float128}, ivsgci::Ptr{Cint},
                                     grad::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_cgrdh_q_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac, lh1, h)
   ptr_cutest_cint_cgrdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cgrdh_q_)
-  @ccall $ptr_cutest_cint_cgrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                   y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, g::Ptr{Cfloat128},
+  @ccall $ptr_cutest_cint_cgrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                   y::Ptr{Float128}, grlagf::Ptr{Bool}, g::Ptr{Float128},
                                    jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
-                                   cjac::Ptr{Cfloat128}, lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+                                   cjac::Ptr{Float128}, lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
 function cutest_cdh_q_(status, n, m, x, y, lh1, h)
   ptr_cutest_cdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdh_q_)
-  @ccall $ptr_cutest_cdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                            y::Ptr{Cfloat128}, lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                            y::Ptr{Float128}, lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
 function cutest_cdhc_q_(status, n, m, x, y, lh1, h)
   ptr_cutest_cdhc_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdhc_q_)
-  @ccall $ptr_cutest_cdhc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                             y::Ptr{Cfloat128}, lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cdhc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                             y::Ptr{Float128}, lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
 function cutest_cdhj_q_(status, n, m, x, y0, y, lh1, h)
   ptr_cutest_cdhj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdhj_q_)
-  @ccall $ptr_cutest_cdhj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                             y0::Ptr{Cfloat128}, y::Ptr{Cfloat128}, lh1::Ptr{Cint},
-                             h::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cdhj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                             y0::Ptr{Float128}, y::Ptr{Float128}, lh1::Ptr{Cint},
+                             h::Ptr{Float128})::Cvoid
 end
 
 function cutest_cshp_q_(status, n, nnzh, lh, irnh, icnh)
@@ -1456,50 +1456,50 @@ end
 
 function cutest_csh_q_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
   ptr_cutest_csh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_csh_q_)
-  @ccall $ptr_cutest_csh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                            y::Ptr{Cfloat128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128},
+  @ccall $ptr_cutest_csh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                            y::Ptr{Float128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128},
                             irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cshc_q_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
   ptr_cutest_cshc_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshc_q_)
-  @ccall $ptr_cutest_cshc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                             y::Ptr{Cfloat128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128},
+  @ccall $ptr_cutest_cshc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                             y::Ptr{Float128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cshj_q_(status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
   ptr_cutest_cshj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshj_q_)
-  @ccall $ptr_cutest_cshj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                             y0::Ptr{Cfloat128}, y::Ptr{Cfloat128}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
-                             h::Ptr{Cfloat128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+  @ccall $ptr_cutest_cshj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                             y0::Ptr{Float128}, y::Ptr{Float128}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
+                             h::Ptr{Float128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_ceh_q_(status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
                             byrows)
   ptr_cutest_cint_ceh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ceh_q_)
-  @ccall $ptr_cutest_cint_ceh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                 y::Ptr{Cfloat128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
+  @ccall $ptr_cutest_cint_ceh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                 y::Ptr{Float128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                  iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
-                                 lhi::Ptr{Cint}, hi::Ptr{Cfloat128}, byrows::Ptr{Bool})::Cvoid
+                                 lhi::Ptr{Cint}, hi::Ptr{Float128}, byrows::Ptr{Bool})::Cvoid
 end
 
 function cutest_cifn_q_(status, n, iprob, x, f)
   ptr_cutest_cifn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cifn_q_)
-  @ccall $ptr_cutest_cifn_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Cfloat128},
-                             f::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cifn_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float128},
+                             f::Ptr{Float128})::Cvoid
 end
 
 function cutest_cigr_q_(status, n, iprob, x, g)
   ptr_cutest_cigr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cigr_q_)
-  @ccall $ptr_cutest_cigr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Cfloat128},
-                             g::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cigr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float128},
+                             g::Ptr{Float128})::Cvoid
 end
 
 function cutest_cisgr_q_(status, n, iprob, x, nnzg, lg, sg, ivsg)
   ptr_cutest_cisgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cisgr_q_)
-  @ccall $ptr_cutest_cisgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Cfloat128},
-                              nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Cfloat128},
+  @ccall $ptr_cutest_cisgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float128},
+                              nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Float128},
                               ivsg::Ptr{Cint})::Cvoid
 end
 
@@ -1511,25 +1511,25 @@ end
 
 function cutest_cidh_q_(status, n, x, iprob, lh1, h)
   ptr_cutest_cidh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cidh_q_)
-  @ccall $ptr_cutest_cidh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, iprob::Ptr{Cint},
-                             lh1::Ptr{Cint}, h::Ptr{Cfloat128})::Cvoid
+  @ccall $ptr_cutest_cidh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, iprob::Ptr{Cint},
+                             lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
 function cutest_cish_q_(status, n, x, iprob, nnzh, lh, h, irnh, icnh)
   ptr_cutest_cish_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cish_q_)
-  @ccall $ptr_cutest_cish_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Cfloat128}, iprob::Ptr{Cint},
-                             nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Cfloat128}, irnh::Ptr{Cint},
+  @ccall $ptr_cutest_cish_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, iprob::Ptr{Cint},
+                             nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint},
                              icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_csgrsh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, nnzh,
                                lh, h, irnh, icnh)
   ptr_cutest_cint_csgrsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgrsh_q_)
-  @ccall $ptr_cutest_cint_csgrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                    y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
-                                    lcjac::Ptr{Cint}, cjac::Ptr{Cfloat128}, indvar::Ptr{Cint},
+  @ccall $ptr_cutest_cint_csgrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                    y::Ptr{Float128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
+                                    lcjac::Ptr{Cint}, cjac::Ptr{Float128}, indvar::Ptr{Cint},
                                     indfun::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
-                                    h::Ptr{Cfloat128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+                                    h::Ptr{Float128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_csgrshp_q_(status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
@@ -1542,73 +1542,73 @@ end
 function cutest_cint_csgreh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, ne,
                                le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
   ptr_cutest_cint_csgreh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgreh_q_)
-  @ccall $ptr_cutest_cint_csgreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Cfloat128},
-                                    y::Ptr{Cfloat128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
-                                    lcjac::Ptr{Cint}, cjac::Ptr{Cfloat128}, indvar::Ptr{Cint},
+  @ccall $ptr_cutest_cint_csgreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
+                                    y::Ptr{Float128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
+                                    lcjac::Ptr{Cint}, cjac::Ptr{Float128}, indvar::Ptr{Cint},
                                     indfun::Ptr{Cint}, ne::Ptr{Cint}, le::Ptr{Cint},
                                     iprnhi::Ptr{Cint}, iprhi::Ptr{Cint}, lirnhi::Ptr{Cint},
-                                    irnhi::Ptr{Cint}, lhi::Ptr{Cint}, hi::Ptr{Cfloat128},
+                                    irnhi::Ptr{Cint}, lhi::Ptr{Cint}, hi::Ptr{Float128},
                                     byrows::Ptr{Bool})::Cvoid
 end
 
 function cutest_cint_chprod_q_(status, n, m, goth, x, y, p, q)
   ptr_cutest_cint_chprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chprod_q_)
   @ccall $ptr_cutest_cint_chprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
-                                    x::Ptr{Cfloat128}, y::Ptr{Cfloat128}, p::Ptr{Cfloat128},
-                                    q::Ptr{Cfloat128})::Cvoid
+                                    x::Ptr{Float128}, y::Ptr{Float128}, p::Ptr{Float128},
+                                    q::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_chsprod_q_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
   ptr_cutest_cint_chsprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chsprod_q_)
   @ccall $ptr_cutest_cint_chsprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
-                                     x::Ptr{Cfloat128}, y::Ptr{Cfloat128}, nnzp::Ptr{Cint},
-                                     indp::Ptr{Cint}, p::Ptr{Cfloat128}, nnzr::Ptr{Cint},
-                                     indr::Ptr{Cint}, r::Ptr{Cfloat128})::Cvoid
+                                     x::Ptr{Float128}, y::Ptr{Float128}, nnzp::Ptr{Cint},
+                                     indp::Ptr{Cint}, p::Ptr{Float128}, nnzr::Ptr{Cint},
+                                     indr::Ptr{Cint}, r::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_chcprod_q_(status, n, m, goth, x, y, p, q)
   ptr_cutest_cint_chcprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chcprod_q_)
   @ccall $ptr_cutest_cint_chcprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
-                                     x::Ptr{Cfloat128}, y::Ptr{Cfloat128}, p::Ptr{Cfloat128},
-                                     q::Ptr{Cfloat128})::Cvoid
+                                     x::Ptr{Float128}, y::Ptr{Float128}, p::Ptr{Float128},
+                                     q::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_cshcprod_q_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
   ptr_cutest_cint_cshcprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cshcprod_q_)
   @ccall $ptr_cutest_cint_cshcprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
-                                      goth::Ptr{Bool}, x::Ptr{Cfloat128}, y::Ptr{Cfloat128},
-                                      nnzp::Ptr{Cint}, indp::Ptr{Cint}, p::Ptr{Cfloat128},
-                                      nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Cfloat128})::Cvoid
+                                      goth::Ptr{Bool}, x::Ptr{Float128}, y::Ptr{Float128},
+                                      nnzp::Ptr{Cint}, indp::Ptr{Cint}, p::Ptr{Float128},
+                                      nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_chjprod_q_(status, n, m, goth, x, y0, y, p, q)
   ptr_cutest_cint_chjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chjprod_q_)
   @ccall $ptr_cutest_cint_chjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
-                                     x::Ptr{Cfloat128}, y0::Ptr{Cfloat128}, y::Ptr{Cfloat128},
-                                     p::Ptr{Cfloat128}, q::Ptr{Cfloat128})::Cvoid
+                                     x::Ptr{Float128}, y0::Ptr{Float128}, y::Ptr{Float128},
+                                     p::Ptr{Float128}, q::Ptr{Float128})::Cvoid
 end
 
 function cutest_cint_cjprod_q_(status, n, m, gotj, jtrans, x, p, lp, r, lr)
   ptr_cutest_cint_cjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cjprod_q_)
   @ccall $ptr_cutest_cint_cjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
-                                    jtrans::Ptr{Bool}, x::Ptr{Cfloat128}, p::Ptr{Cfloat128},
-                                    lp::Ptr{Cint}, r::Ptr{Cfloat128}, lr::Ptr{Cint})::Cvoid
+                                    jtrans::Ptr{Bool}, x::Ptr{Float128}, p::Ptr{Float128},
+                                    lp::Ptr{Cint}, r::Ptr{Float128}, lr::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_csjprod_q_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr, indr, r, lr)
   ptr_cutest_cint_csjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csjprod_q_)
   @ccall $ptr_cutest_cint_csjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
-                                     jtrans::Ptr{Bool}, x::Ptr{Cfloat128}, nnzp::Ptr{Cint},
-                                     indp::Ptr{Cint}, p::Ptr{Cfloat128}, lp::Ptr{Cint},
-                                     nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Cfloat128},
+                                     jtrans::Ptr{Bool}, x::Ptr{Float128}, nnzp::Ptr{Cint},
+                                     indp::Ptr{Cint}, p::Ptr{Float128}, lp::Ptr{Cint},
+                                     nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Float128},
                                      lr::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_cchprods_q_(status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
   ptr_cutest_cint_cchprods_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cchprods_q_)
   @ccall $ptr_cutest_cint_cchprods_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
-                                      goth::Ptr{Bool}, x::Ptr{Cfloat128}, p::Ptr{Cfloat128},
-                                      lchp::Ptr{Cint}, chpval::Ptr{Cfloat128}, chpind::Ptr{Cint},
+                                      goth::Ptr{Bool}, x::Ptr{Float128}, p::Ptr{Float128},
+                                      lchp::Ptr{Cint}, chpval::Ptr{Float128}, chpind::Ptr{Cint},
                                       chpptr::Ptr{Cint})::Cvoid
 end
 
@@ -1621,8 +1621,8 @@ end
 function cutest_cint_cohprods_q_(status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
   ptr_cutest_cint_cohprods_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cohprods_q_)
   @ccall $ptr_cutest_cint_cohprods_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
-                                      x::Ptr{Cfloat128}, p::Ptr{Cfloat128}, nnzohp::Ptr{Cint},
-                                      lohp::Ptr{Cint}, ohpval::Ptr{Cfloat128},
+                                      x::Ptr{Float128}, p::Ptr{Float128}, nnzohp::Ptr{Cint},
+                                      lohp::Ptr{Cint}, ohpval::Ptr{Float128},
                                       ohpind::Ptr{Cint})::Cvoid
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -84,10 +84,10 @@ function CUTEstModel(
     T = Float64
     global cutest_instances_double
     cutest_instances_double > 0 && error("CUTEst: call finalize on current model first")
-    # elseif precision == :quadruple
-    #   T = Float128
-    #   global cutest_instances_quadruple
-    #   cutest_instances_quadruple > 0 && error("CUTEst: call finalize on current model first")
+  elseif precision == :quadruple
+    T = Float128
+    global cutest_instances_quadruple
+    cutest_instances_quadruple > 0 && error("CUTEst: call finalize on current model first")
   else
     error("The $precision precision is not supported.")
   end
@@ -312,9 +312,9 @@ function cutest_finalize(nlp::CUTEstModel{T}) where {T}
   elseif T == Float64
     global cutest_instances_double
     cutest_instances_double == 0 && return
-    # else  # precision = :quadruple
-    #   global cutest_instances_quadruple
-    #   cutest_instances_quadruple == 0 && return
+    else  # precision = :quadruple
+      global cutest_instances_quadruple
+      cutest_instances_quadruple == 0 && return
   end
   status = Ref{Cint}(0)
   if nlp.meta.ncon > 0
@@ -333,11 +333,11 @@ function cutest_finalize(nlp::CUTEstModel{T}) where {T}
     Libdl.dlclose(cutest_lib_double)
     cutest_instances_double -= 1
     cutest_lib_double = C_NULL
-    # else  # precision = :quadruple
-    #   global cutest_lib_quadruple
-    #   Libdl.dlclose(cutest_lib_quadruple)
-    #   cutest_instances_quadruple -= 1
-    #   cutest_lib_quadruple = C_NULL
+    else  # precision = :quadruple
+      global cutest_lib_quadruple
+      Libdl.dlclose(cutest_lib_quadruple)
+      cutest_instances_quadruple -= 1
+      cutest_lib_quadruple = C_NULL
   end
   return
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ include("coverage.jl")
 include("multiple_precision.jl")
 
 for problem in problems
-  for (T, precision) in [(Float32, :single), (Float64, :double)]
+  for (T, precision) in [(Float32, :single), (Float64, :double), (Float128, :quadruple)]
     println("Testing interfaces on problem $problem in $precision precision")
     nlp = CUTEstModel(problem, precision = precision)
     nlp_man = eval(Symbol(problem))(T)
@@ -47,7 +47,7 @@ problems = CUTEst.select(max_var = 2, max_con = 2)
 problems = randsubseq(problems, 0.1)
 
 for p in problems
-  for (T, precision) in [(Float32, :single), (Float64, :double)]
+  for (T, precision) in [(Float32, :single), (Float64, :double), (Float128, :quadruple)]
     nlp = CUTEstModel(p, precision = precision)
     x0 = nlp.meta.x0
     nvar, ncon = nlp.meta.nvar, nlp.meta.ncon
@@ -79,7 +79,7 @@ finalize(nlp)
 
 @testset "Test decoding separately (issue #239)" begin
   problems = ["AKIVA", "ROSENBR", "ZANGWIL2"]
-  for (T, precision) in [(Float32, :single), (Float64, :double)]
+  for (T, precision) in [(Float32, :single), (Float64, :double), (Float128, :quadruple)]
     # Decoding
     for p in problems
       nlp = CUTEstModel(p, precision = precision)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@
 using LinearAlgebra, SparseArrays, Random, Test
 # jso
 using CUTEst, NLPModels, NLPModelsTest
+# external
+using Quadmath
 
 set_mastsif()
 @test ispath(ENV["MASTSIF"])

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -12,7 +12,9 @@ function test_coreinterface(
   c(x) = cons(comp_nlp, x)
   J(x) = jac(comp_nlp, x)
   W(x, y; obj_weight = one(T)) = hess(comp_nlp, x, y, obj_weight = obj_weight)
+
   rtol = eps(T) |> sqrt
+  rtol = max(rtol, T(1e-8))
 
   if !test_view
     st = Cint[0]

--- a/test/test_julia.jl
+++ b/test/test_julia.jl
@@ -16,6 +16,7 @@ function test_nlpinterface(nlp::CUTEstModel{T}, comp_nlp::AbstractNLPModel{T}) w
   u = ones(T, nlp.meta.ncon)
 
   rtol = eps(T) |> sqrt
+  rtol = max(rtol, T(1e-8))
 
   @testset "Julia interface" begin
     fx = obj(nlp, x0)


### PR DESCRIPTION
@oscardssmith @RalphAS 
Do you know what is the best way to provide a `Vector` of a `Ref` of `Float128` to a Fortran routine?
The Fortran routines probably needs a Vector of `Cfloat128`, am I right?