### PR TITLE
Multiple instances of CUTEstModel can now coexist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ If you use CUTEst.jl in your work, please cite using the format given in [CITATI
 ## Installing
 
 This package will automatically install the CUTEst binaries for your platform.
-The `gfortran` compiler is required to compile decoded SIF problems. Users on all platforms except Windows must install it to use CUTEst.jl.
+The `gfortran` compiler is required to compile decoded SIF problems.
+Users on all platforms except Windows must install it to use CUTEst.jl.
 For Windows users, a small artifact containing `gfortran.exe` is installed automatically.
 No other Fortran compiler is supported.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ If you use CUTEst.jl in your work, please cite using the format given in [CITATI
 ## Installing
 
 This package will automatically install the CUTEst binaries for your platform.
-The `gfortran` compiler is required to compile decoded SIF problems, except on Windows.
+The `gfortran` compiler is required to compile decoded SIF problems. Users on all platforms except Windows must install it to use CUTEst.jl.
+For Windows users, a small artifact containing `gfortran.exe` is installed automatically.
 No other Fortran compiler is supported.
 
 The following command installs the CUTEst binaries and the Julia interface:
@@ -82,34 +83,6 @@ set_mastsif("netlib-lp")
 ```
 
 The constructor `CUTEstModel{Float64}(name)` will try to find the SIF file associated with the problem `name` in the current set.
-
-### Run multiple models in parallel
-
-First, decode each of the problems in serial.
-
-```julia
-function decodemodel(name)
-    finalize(CUTEstModel(name))
-end
-
-probs = ["AKIVA", "ALLINITU", "ARGLINA", "ARGLINB", "ARGLINC", "ARGTRIGLS", "ARWHEAD"]
-broadcast(decodemodel, probs)
-```
-
-Then, call functions handling models in parallel. It is important to pass `decode=false` to `CUTEstModel`.
-
-```julia
-addprocs(2)
-@everywhere using CUTEst
-@everywhere function evalmodel(name)
-   nlp = CUTEstModel(name; decode=false)
-   retval = obj(nlp, nlp.meta.x0)
-   finalize(nlp)
-   retval
-end
-
-fvals = pmap(evalmodel, probs)
-```
 
 ## Related Packages
 

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -9,14 +9,6 @@ using Quadmath
 using NLPModels
 import Libdl.dlsym
 
-# Only one problem can be interfaced at any given time.
-global cutest_instances_single = 0
-global cutest_instances_double = 0
-global cutest_instances_quadruple = 0
-global cutest_lib_single = C_NULL
-global cutest_lib_double = C_NULL
-global cutest_lib_quadruple = C_NULL
-
 export CUTEstModel, sifdecoder, build_libsif, set_mastsif
 
 const cutest_problems_path = joinpath(dirname(@__FILE__), "..", "deps", "files")

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -1,5 +1,5 @@
 """
-    usetup(T, status, input, out, io_buffer, n, x, x_l, x_u)
+    usetup(T, libsif, status, input, out, io_buffer, n, x, x_l, x_u)
 
 The usetup subroutine sets up the correct data structures for
 subsequent computations in the case where the only possible
@@ -24,6 +24,7 @@ for (cutest_usetup, T) in
   @eval begin
     function usetup(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       input::StrideOneVector{Cint},
       out::StrideOneVector{Cint},
@@ -33,13 +34,13 @@ for (cutest_usetup, T) in
       x_l::StrideOneVector{$T},
       x_u::StrideOneVector{$T},
     )
-      $cutest_usetup(status, input, out, io_buffer, n, x, x_l, x_u)
+      $cutest_usetup(libsif, status, input, out, io_buffer, n, x, x_l, x_u)
     end
   end
 end
 
 """
-    csetup(status, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn, linear, e_order, l_order, v_order)
+    csetup(libsif, status, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn, linear, e_order, l_order, v_order)
 
 The csetup subroutine sets up the correct data structures for
 subsequent computations on the problem decoded from a SIF file by the
@@ -78,6 +79,7 @@ for (cutest_cint_csetup, T) in (
   @eval begin
     function csetup(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       input::StrideOneVector{Cint},
       out::StrideOneVector{Cint},
@@ -97,6 +99,7 @@ for (cutest_cint_csetup, T) in (
       v_order::StrideOneVector{Cint},
     )
       $cutest_cint_csetup(
+        libsif,
         status,
         input,
         out,
@@ -120,7 +123,7 @@ for (cutest_cint_csetup, T) in (
 end
 
 """
-    udimen(T, status, input, n)
+    udimen(T, libsif, status, input, n)
 
 The udimen subroutine discovers how many variables are involved in the
 problem decoded from a SIF file by the script sifdecoder. The problem
@@ -139,17 +142,18 @@ for (cutest_udimen, T) in
   @eval begin
     function udimen(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       input::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
     )
-      $cutest_udimen(status, input, n)
+      $cutest_udimen(libsif, status, input, n)
     end
   end
 end
 
 """
-    udimsh(T, status, nnzh)
+    udimsh(T, libsif, status, nnzh)
 
 The udimsh subroutine determine the number of nonzeros required to
 store the Hessian matrix of the objective function of the problem
@@ -167,14 +171,14 @@ function udimsh end
 for (cutest_udimsh, T) in
     ((:cutest_udimsh_s_, :Float32), (:cutest_udimsh_, :Float64), (:cutest_udimsh_q_, :Float128))
   @eval begin
-    function udimsh(::Type{$T}, status::StrideOneVector{Cint}, nnzh::StrideOneVector{Cint})
-      $cutest_udimsh(status, nnzh)
+    function udimsh(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint}, nnzh::StrideOneVector{Cint})
+      $cutest_udimsh(libsif, status, nnzh)
     end
   end
 end
 
 """
-    udimse(T, status, ne, he_val_ne, he_row_ne)
+    udimse(T, libsif, status, ne, he_val_ne, he_row_ne)
 
 The udimse subroutine determine the number of nonzeros required to
 store the Hessian matrix of the objective function of the problem
@@ -198,18 +202,19 @@ for (cutest_udimse, T) in
   @eval begin
     function udimse(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       ne::StrideOneVector{Cint},
       he_val_ne::StrideOneVector{Cint},
       he_row_ne::StrideOneVector{Cint},
     )
-      $cutest_udimse(status, ne, he_val_ne, he_row_ne)
+      $cutest_udimse(libsif, status, ne, he_val_ne, he_row_ne)
     end
   end
 end
 
 """
-    uvartype(T, status, n, x_type)
+    uvartype(T, libsif, status, n, x_type)
 
 The uvartype subroutine determines the type (continuous, 0-1, integer)
 of each variable involved in the problem decoded from a SIF file by
@@ -232,17 +237,18 @@ for (cutest_uvartype, T) in (
   @eval begin
     function uvartype(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x_type::StrideOneVector{Cint},
     )
-      $cutest_uvartype(status, n, x_type)
+      $cutest_uvartype(libsif, status, n, x_type)
     end
   end
 end
 
 """
-    unames(T, status, n, pname, vname)
+    unames(T, libsif, status, n, pname, vname)
 
 The unames subroutine obtains the names of the problem and its
 variables. The problem under consideration is to minimize or maximize
@@ -263,18 +269,19 @@ for (cutest_unames, T) in
   @eval begin
     function unames(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       pname::StrideOneVector{Cchar},
       vname::Matrix{Cchar},
     )
-      $cutest_unames(status, n, pname, vname)
+      $cutest_unames(libsif, status, n, pname, vname)
     end
   end
 end
 
 """
-    ureport(T, status, calls, time)
+    ureport(T, libsif, status, calls, time)
 
 The ureport subroutine obtains statistics concerning function
 evaluation and CPU time used for unconstrained or bound-constrained
@@ -294,17 +301,18 @@ for (cutest_ureport, T) in
   @eval begin
     function ureport(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       calls::StrideOneVector{$T},
       time::StrideOneVector{$T},
     )
-      $cutest_ureport(status, calls, time)
+      $cutest_ureport(libsif, status, calls, time)
     end
   end
 end
 
 """
-    cdimen(T, status, input, n, m)
+    cdimen(T, libsif, status, input, n, m)
 
 The cdimen subroutine discovers how many variables and constraints are
 involved in the problem decoded from a SIF file by the script
@@ -327,18 +335,19 @@ for (cutest_cdimen, T) in
   @eval begin
     function cdimen(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       input::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
     )
-      $cutest_cdimen(status, input, n, m)
+      $cutest_cdimen(libsif, status, input, n, m)
     end
   end
 end
 
 """
-    cdimsj(T, status, nnzj)
+    cdimsj(T, libsif, status, nnzj)
 
 The cdimsj subroutine determines the number of nonzero elements
 required to store the matrix of gradients of the objective function
@@ -359,14 +368,14 @@ function cdimsj end
 for (cutest_cdimsj, T) in
     ((:cutest_cdimsj_s_, :Float32), (:cutest_cdimsj_, :Float64), (:cutest_cdimsj_q_, :Float128))
   @eval begin
-    function cdimsj(::Type{$T}, status::StrideOneVector{Cint}, nnzj::StrideOneVector{Cint})
-      $cutest_cdimsj(status, nnzj)
+    function cdimsj(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint}, nnzj::StrideOneVector{Cint})
+      $cutest_cdimsj(libsif, status, nnzj)
     end
   end
 end
 
 """
-    cdimsh(T, status, nnzh)
+    cdimsh(T, libsif, status, nnzh)
 
 The cdimsh subroutine determines the number of nonzero elements
 required to store the Hessian matrix of the Lagrangian function for
@@ -386,14 +395,14 @@ function cdimsh end
 for (cutest_cdimsh, T) in
     ((:cutest_cdimsh_s_, :Float32), (:cutest_cdimsh_, :Float64), (:cutest_cdimsh_q_, :Float128))
   @eval begin
-    function cdimsh(::Type{$T}, status::StrideOneVector{Cint}, nnzh::StrideOneVector{Cint})
-      $cutest_cdimsh(status, nnzh)
+    function cdimsh(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint}, nnzh::StrideOneVector{Cint})
+      $cutest_cdimsh(libsif, status, nnzh)
     end
   end
 end
 
 """
-    cdimchp(T, status, nnzchp)
+    cdimchp(T, libsif, status, nnzchp)
 
 The cdimchp subroutine determines the number of nonzero elements
 required to store the products of the Hessian matrices of the
@@ -413,14 +422,14 @@ function cdimchp end
 for (cutest_cdimchp, T) in
     ((:cutest_cdimchp_s_, :Float32), (:cutest_cdimchp_, :Float64), (:cutest_cdimchp_q_, :Float128))
   @eval begin
-    function cdimchp(::Type{$T}, status::StrideOneVector{Cint}, nnzchp::StrideOneVector{Cint})
-      $cutest_cdimchp(status, nnzchp)
+    function cdimchp(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint}, nnzchp::StrideOneVector{Cint})
+      $cutest_cdimchp(libsif, status, nnzchp)
     end
   end
 end
 
 """
-    cdimse(T, status, ne, he_val_ne, he_row_ne)
+    cdimse(T, libsif, status, ne, he_val_ne, he_row_ne)
 
 The cdimse subroutine determines the number of nonzero elements
 required to store the Hessian matrix of the Lagrangian function for
@@ -446,18 +455,19 @@ for (cutest_cdimse, T) in
   @eval begin
     function cdimse(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       ne::StrideOneVector{Cint},
       he_val_ne::StrideOneVector{Cint},
       he_row_ne::StrideOneVector{Cint},
     )
-      $cutest_cdimse(status, ne, he_val_ne, he_row_ne)
+      $cutest_cdimse(libsif, status, ne, he_val_ne, he_row_ne)
     end
   end
 end
 
 """
-    cstats(T, status, nonlinear_variables_objective, nonlinear_variables_constraints, equality_constraints, linear_constraints)
+    cstats(T, libsif, status, nonlinear_variables_objective, nonlinear_variables_constraints, equality_constraints, linear_constraints)
 
   - status:                          [OUT] Vector{Cint}
   - nonlinear_variables_objective:   [OUT] Vector{Cint}
@@ -472,6 +482,7 @@ for (cutest_cstats, T) in
   @eval begin
     function cstats(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       nonlinear_variables_objective::StrideOneVector{Cint},
       nonlinear_variables_constraints::StrideOneVector{Cint},
@@ -479,6 +490,7 @@ for (cutest_cstats, T) in
       linear_constraints::StrideOneVector{Cint},
     )
       $cutest_cstats(
+        libsif,
         status,
         nonlinear_variables_objective,
         nonlinear_variables_constraints,
@@ -490,7 +502,7 @@ for (cutest_cstats, T) in
 end
 
 """
-    cvartype(T, status, n, x_type)
+    cvartype(T, libsif, status, n, x_type)
 
 The cvartype subroutine determines the type (continuous, 0-1, integer)
 of each variable involved in the problem decoded from a SIF file by
@@ -515,17 +527,18 @@ for (cutest_cvartype, T) in (
   @eval begin
     function cvartype(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x_type::StrideOneVector{Cint},
     )
-      $cutest_cvartype(status, n, x_type)
+      $cutest_cvartype(libsif, status, n, x_type)
     end
   end
 end
 
 """
-    cnames(T, status, n, m, pname, vname, cname)
+    cnames(T, libsif, status, n, m, pname, vname, cname)
 
 The cnames subroutine obtains the names of the problem, its variables
 and general constraints. The problem under consideration is to
@@ -552,6 +565,7 @@ for (cutest_cnames, T) in
   @eval begin
     function cnames(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -559,13 +573,13 @@ for (cutest_cnames, T) in
       vname::Matrix{Cchar},
       cname::Matrix{Cchar},
     )
-      $cutest_cnames(status, n, m, pname, vname, cname)
+      $cutest_cnames(libsif, status, n, m, pname, vname, cname)
     end
   end
 end
 
 """
-    creport(T, status, calls, time)
+    creport(T, libsif, status, calls, time)
 
 The creport subroutine obtains statistics concerning function
 evaluation and CPU time used for constrained optimization in a
@@ -587,17 +601,18 @@ for (cutest_creport, T) in
   @eval begin
     function creport(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       calls::StrideOneVector{$T},
       time::StrideOneVector{$T},
     )
-      $cutest_creport(status, calls, time)
+      $cutest_creport(libsif, status, calls, time)
     end
   end
 end
 
 """
-    connames(T, status, m, cname)
+    connames(T, libsif, status, m, cname)
 
 The connames subroutine obtains the names of the general constraints
 of the problem. The problem under consideration is to minimize or
@@ -623,17 +638,18 @@ for (cutest_connames, T) in (
   @eval begin
     function connames(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
       cname::Matrix{Cchar},
     )
-      $cutest_connames(status, m, cname)
+      $cutest_connames(libsif, status, m, cname)
     end
   end
 end
 
 """
-    pname(T, status, input, pname)
+    pname(T, libsif, status, input, pname)
 
 The pname subroutine obtains the name of the problem directly from the
 datafile OUTSDIF.d that was created by the script sifdecoder when
@@ -655,17 +671,18 @@ for (cutest_pname, T) in
   @eval begin
     function pname(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       input::StrideOneVector{Cint},
       pname::StrideOneVector{Cchar},
     )
-      $cutest_pname(status, input, pname)
+      $cutest_pname(libsif, status, input, pname)
     end
   end
 end
 
 """
-    probname(T, status, pname)
+    probname(T, libsif, status, pname)
 
 The probname subroutine obtains the name of the problem. The problem
 under consideration is to minimize or maximize an objective function
@@ -687,14 +704,14 @@ for (cutest_probname, T) in (
   (:cutest_probname_q_, :Float128),
 )
   @eval begin
-    function probname(::Type{$T}, status::StrideOneVector{Cint}, pname::StrideOneVector{Cchar})
-      $cutest_probname(status, pname)
+    function probname(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint}, pname::StrideOneVector{Cchar})
+      $cutest_probname(libsif, status, pname)
     end
   end
 end
 
 """
-    varnames(T, status, n, vname)
+    varnames(T, libsif, status, n, vname)
 
 The varnames subroutine obtains the names of the problem variables.
 The problem under consideration is to minimize or maximize an
@@ -720,17 +737,18 @@ for (cutest_varnames, T) in (
   @eval begin
     function varnames(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       vname::Matrix{Cchar},
     )
-      $cutest_varnames(status, n, vname)
+      $cutest_varnames(libsif, status, n, vname)
     end
   end
 end
 
 """
-    ufn(T, status, n, x, f)
+    ufn(T, libsif, status, n, x, f)
 
 The ufn subroutine evaluates the value of the objective function of
 the problem decoded from a SIF file by the script sifdecoder at the
@@ -750,18 +768,19 @@ for (cutest_ufn, T) in
   @eval begin
     function ufn(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
       f::StrideOneVector{$T},
     )
-      $cutest_ufn(status, n, x, f)
+      $cutest_ufn(libsif, status, n, x, f)
     end
   end
 end
 
 """
-    ugr(T, status, n, x, g)
+    ugr(T, libsif, status, n, x, g)
 
 The ugr subroutine evaluates the gradient of the objective function of
 the problem decoded from a SIF file by the script sifdecoder at the
@@ -781,18 +800,19 @@ for (cutest_ugr, T) in
   @eval begin
     function ugr(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
       g::StrideOneVector{$T},
     )
-      $cutest_ugr(status, n, x, g)
+      $cutest_ugr(libsif, status, n, x, g)
     end
   end
 end
 
 """
-    uofg(T, status, n, x, f, g, grad)
+    uofg(T, libsif, status, n, x, f, g, grad)
 
 The uofg subroutine evaluates the value of the objective function of
 the problem decoded from a SIF file by the script sifdecoder at the
@@ -818,6 +838,7 @@ for (cutest_cint_uofg, T) in (
   @eval begin
     function uofg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -825,13 +846,13 @@ for (cutest_cint_uofg, T) in (
       g::StrideOneVector{$T},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_uofg(status, n, x, f, g, grad)
+      $cutest_cint_uofg(libsif, status, n, x, f, g, grad)
     end
   end
 end
 
 """
-    udh(T, status, n, x, lh1, h)
+    udh(T, libsif, status, n, x, lh1, h)
 
 The udh subroutine evaluates the Hessian matrix of the objective
 function of the problem decoded from a SIF file by the script
@@ -853,19 +874,20 @@ for (cutest_udh, T) in
   @eval begin
     function udh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
       lh1::StrideOneVector{Cint},
       h::Matrix{$T},
     )
-      $cutest_udh(status, n, x, lh1, h)
+      $cutest_udh(libsif, status, n, x, lh1, h)
     end
   end
 end
 
 """
-    ushp(T, status, n, nnzh, lh, h_row, h_col)
+    ushp(T, libsif, status, n, nnzh, lh, h_row, h_col)
 
 The ushp subroutine evaluates the sparsity pattern of the Hessian
 matrix of the objective function of the problem, decoded from a SIF
@@ -888,6 +910,7 @@ for (cutest_ushp, T) in
   @eval begin
     function ushp(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       nnzh::StrideOneVector{Cint},
@@ -895,13 +918,13 @@ for (cutest_ushp, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_ushp(status, n, nnzh, lh, h_row, h_col)
+      $cutest_ushp(libsif, status, n, nnzh, lh, h_row, h_col)
     end
   end
 end
 
 """
-    ush(T, status, n, x, nnzh, lh, h_val, h_row, h_col)
+    ush(T, libsif, status, n, x, nnzh, lh, h_val, h_row, h_col)
 
 The ush subroutine evaluates the Hessian matrix of the objective
 function of the problem decoded from a SIF file by the script
@@ -927,6 +950,7 @@ for (cutest_ush, T) in
   @eval begin
     function ush(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -936,13 +960,13 @@ for (cutest_ush, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_ush(status, n, x, nnzh, lh, h_val, h_row, h_col)
+      $cutest_ush(libsif, status, n, x, nnzh, lh, h_val, h_row, h_col)
     end
   end
 end
 
 """
-    ueh(T, status, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+    ueh(T, libsif, status, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
 
 The ueh subroutine evaluates the Hessian matrix of the objective
 function of the problem decoded from a SIF file by the script
@@ -976,6 +1000,7 @@ for (cutest_cint_ueh, T) in (
   @eval begin
     function ueh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -990,6 +1015,7 @@ for (cutest_cint_ueh, T) in (
       byrows::StrideOneVector{Bool},
     )
       $cutest_cint_ueh(
+        libsif,
         status,
         n,
         x,
@@ -1008,7 +1034,7 @@ for (cutest_cint_ueh, T) in (
 end
 
 """
-    ugrdh(T, status, n, x, g, lh1, h)
+    ugrdh(T, libsif, status, n, x, g, lh1, h)
 
 The ugrdh subroutine evaluates the gradient and Hessian matrix of the
 objective function of the problem decoded from a SIF file by the
@@ -1032,6 +1058,7 @@ for (cutest_ugrdh, T) in
   @eval begin
     function ugrdh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -1039,13 +1066,13 @@ for (cutest_ugrdh, T) in
       lh1::StrideOneVector{Cint},
       h::Matrix{$T},
     )
-      $cutest_ugrdh(status, n, x, g, lh1, h)
+      $cutest_ugrdh(libsif, status, n, x, g, lh1, h)
     end
   end
 end
 
 """
-    ugrsh(T, status, n, x, g, nnzh, lh, h_val, h_row, h_col)
+    ugrsh(T, libsif, status, n, x, g, nnzh, lh, h_val, h_row, h_col)
 
 The ugrsh subroutine evaluates the gradient and Hessian matrix of the
 objective function of the problem decoded from a SIF file by the
@@ -1072,6 +1099,7 @@ for (cutest_ugrsh, T) in
   @eval begin
     function ugrsh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -1082,13 +1110,13 @@ for (cutest_ugrsh, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_ugrsh(status, n, x, g, nnzh, lh, h_val, h_row, h_col)
+      $cutest_ugrsh(libsif, status, n, x, g, nnzh, lh, h_val, h_row, h_col)
     end
   end
 end
 
 """
-    ugreh(T, status, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+    ugreh(T, libsif, status, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
 
 The ugreh subroutine evaluates the gradient and Hessian matrix of the
 objective function of the problem decoded from a SIF file by the
@@ -1124,6 +1152,7 @@ for (cutest_cint_ugreh, T) in (
   @eval begin
     function ugreh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -1139,6 +1168,7 @@ for (cutest_cint_ugreh, T) in (
       byrows::StrideOneVector{Bool},
     )
       $cutest_cint_ugreh(
+        libsif,
         status,
         n,
         x,
@@ -1158,7 +1188,7 @@ for (cutest_cint_ugreh, T) in (
 end
 
 """
-    uhprod(T, status, n, goth, x, vector, result)
+    uhprod(T, libsif, status, n, goth, x, vector, result)
 
 The uhprod subroutine forms the product of a vector with the Hessian
 matrix of the objective function of the problem decoded from a SIF
@@ -1184,6 +1214,7 @@ for (cutest_cint_uhprod, T) in (
   @eval begin
     function uhprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       goth::StrideOneVector{Bool},
@@ -1191,13 +1222,13 @@ for (cutest_cint_uhprod, T) in (
       vector::StrideOneVector{$T},
       result::StrideOneVector{$T},
     )
-      $cutest_cint_uhprod(status, n, goth, x, vector, result)
+      $cutest_cint_uhprod(libsif, status, n, goth, x, vector, result)
     end
   end
 end
 
 """
-    ushprod(T, status, n, goth, x, nnz_vector, index_nz_vector, vector, nnz_result, index_nz_result, result)
+    ushprod(T, libsif, status, n, goth, x, nnz_vector, index_nz_vector, vector, nnz_result, index_nz_result, result)
 
 The ushprod subroutine forms the product of a sparse vector with the
 Hessian matrix of the objective function of the problem decoded from a
@@ -1229,6 +1260,7 @@ for (cutest_cint_ushprod, T) in (
   @eval begin
     function ushprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       goth::StrideOneVector{Bool},
@@ -1241,6 +1273,7 @@ for (cutest_cint_ushprod, T) in (
       result::StrideOneVector{$T},
     )
       $cutest_cint_ushprod(
+        libsif,
         status,
         n,
         goth,
@@ -1257,7 +1290,7 @@ for (cutest_cint_ushprod, T) in (
 end
 
 """
-    ubandh(T, status, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
+    ubandh(T, libsif, status, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
 
 The ubandh subroutine extracts the elements which lie within a band of
 given semi-bandwidth out of the Hessian matrix of the objective
@@ -1282,6 +1315,7 @@ for (cutest_ubandh, T) in
   @eval begin
     function ubandh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -1290,13 +1324,13 @@ for (cutest_ubandh, T) in
       lbandh::StrideOneVector{Cint},
       max_semibandwidth::StrideOneVector{Cint},
     )
-      $cutest_ubandh(status, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
+      $cutest_ubandh(libsif, status, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
     end
   end
 end
 
 """
-    cfn(T, status, n, m, x, f, c)
+    cfn(T, libsif, status, n, m, x, f, c)
 
 The cfn subroutine evaluates the value of the objective function and
 general constraint functions of the problem decoded from a SIF file by
@@ -1321,6 +1355,7 @@ for (cutest_cfn, T) in
   @eval begin
     function cfn(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1328,13 +1363,13 @@ for (cutest_cfn, T) in
       f::StrideOneVector{$T},
       c::StrideOneVector{$T},
     )
-      $cutest_cfn(status, n, m, x, f, c)
+      $cutest_cfn(libsif, status, n, m, x, f, c)
     end
   end
 end
 
 """
-    cofg(T, status, n, x, f, g, grad)
+    cofg(T, libsif, status, n, x, f, g, grad)
 
 The cofg subroutine evaluates the value of the objective function of
 the problem decoded from a SIF file by the script sifdecoder at the
@@ -1362,6 +1397,7 @@ for (cutest_cint_cofg, T) in (
   @eval begin
     function cofg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -1369,13 +1405,13 @@ for (cutest_cint_cofg, T) in (
       g::StrideOneVector{$T},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_cofg(status, n, x, f, g, grad)
+      $cutest_cint_cofg(libsif, status, n, x, f, g, grad)
     end
   end
 end
 
 """
-    cofsg(T, status, n, x, f, nnzg, lg, g_val, g_var, grad)
+    cofsg(T, libsif, status, n, x, f, nnzg, lg, g_val, g_var, grad)
 
 The cofsg subroutine evaluates the value of the objective function of
 the problem decoded from a SIF file by the script sifdecoder at the
@@ -1406,6 +1442,7 @@ for (cutest_cint_cofsg, T) in (
   @eval begin
     function cofsg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -1416,13 +1453,13 @@ for (cutest_cint_cofsg, T) in (
       g_var::StrideOneVector{Cint},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_cofsg(status, n, x, f, nnzg, lg, g_val, g_var, grad)
+      $cutest_cint_cofsg(libsif, status, n, x, f, nnzg, lg, g_val, g_var, grad)
     end
   end
 end
 
 """
-    ccfg(T, status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+    ccfg(T, libsif, status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
 
 The ccfg subroutine evaluates the values of the constraint functions
 of the problem decoded from a SIF file by the script sifdecoder at the
@@ -1454,6 +1491,7 @@ for (cutest_cint_ccfg, T) in (
   @eval begin
     function ccfg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1465,13 +1503,13 @@ for (cutest_cint_ccfg, T) in (
       cjac::Matrix{$T},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_ccfg(status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+      $cutest_cint_ccfg(libsif, status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
     end
   end
 end
 
 """
-    clfg(T, status, n, m, x, y, f, g, grad)
+    clfg(T, libsif, status, n, m, x, y, f, g, grad)
 
 The clfg subroutine evaluates the value of the Lagrangian function
 l(x,y)=f(x)+yTc(x) for the problem decoded from a SIF file by the
@@ -1501,6 +1539,7 @@ for (cutest_cint_clfg, T) in (
   @eval begin
     function clfg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1510,13 +1549,13 @@ for (cutest_cint_clfg, T) in (
       g::StrideOneVector{$T},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_clfg(status, n, m, x, y, f, g, grad)
+      $cutest_cint_clfg(libsif, status, n, m, x, y, f, g, grad)
     end
   end
 end
 
 """
-    cgr(T, status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
+    cgr(T, libsif, status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
 
 The cgr subroutine evaluates the gradients of the general constraints
 and of either the objective function f(x) or the Lagrangian function
@@ -1550,6 +1589,7 @@ for (cutest_cint_cgr, T) in (
   @eval begin
     function cgr(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1562,13 +1602,13 @@ for (cutest_cint_cgr, T) in (
       lj2::StrideOneVector{Cint},
       j_val::Matrix{$T},
     )
-      $cutest_cint_cgr(status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
+      $cutest_cint_cgr(libsif, status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
     end
   end
 end
 
 """
-    csgr(T, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
+    csgr(T, libsif, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
 
 The csgr subroutine evaluates the gradients of the general constraints
 and of either the objective function or the Lagrangian function
@@ -1604,6 +1644,7 @@ for (cutest_cint_csgr, T) in (
   @eval begin
     function csgr(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1616,13 +1657,13 @@ for (cutest_cint_csgr, T) in (
       j_var::StrideOneVector{Cint},
       j_fun::StrideOneVector{Cint},
     )
-      $cutest_cint_csgr(status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
+      $cutest_cint_csgr(libsif, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
     end
   end
 end
 
 """
-    ccfsg(T, status, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
+    ccfsg(T, libsif, status, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
 
 The ccfsg subroutine evaluates the values of the constraint functions
 of the problem decoded from a SIF file by the script sifdecoder at the
@@ -1656,6 +1697,7 @@ for (cutest_cint_ccfsg, T) in (
   @eval begin
     function ccfsg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1668,13 +1710,13 @@ for (cutest_cint_ccfsg, T) in (
       j_fun::StrideOneVector{Cint},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_ccfsg(status, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
+      $cutest_cint_ccfsg(libsif, status, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
     end
   end
 end
 
 """
-    ccifg(T, status, n, icon, x, ci, gci, grad)
+    ccifg(T, libsif, status, n, icon, x, ci, gci, grad)
 
 The ccifg subroutine evaluates the value of a particular constraint
 function of the problem decoded from a SIF file by the script
@@ -1704,6 +1746,7 @@ for (cutest_cint_ccifg, T) in (
   @eval begin
     function ccifg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       icon::StrideOneVector{Cint},
@@ -1712,13 +1755,13 @@ for (cutest_cint_ccifg, T) in (
       gci::StrideOneVector{$T},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_ccifg(status, n, icon, x, ci, gci, grad)
+      $cutest_cint_ccifg(libsif, status, n, icon, x, ci, gci, grad)
     end
   end
 end
 
 """
-    ccifsg(T, status, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
+    ccifsg(T, libsif, status, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
 
 The ccifsg subroutine evaluates the value of a particular constraint
 function of the problem decoded from a SIF file by the script
@@ -1752,6 +1795,7 @@ for (cutest_cint_ccifsg, T) in (
   @eval begin
     function ccifsg(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       icon::StrideOneVector{Cint},
@@ -1763,13 +1807,13 @@ for (cutest_cint_ccifsg, T) in (
       gci_var::StrideOneVector{Cint},
       grad::StrideOneVector{Bool},
     )
-      $cutest_cint_ccifsg(status, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
+      $cutest_cint_ccifsg(libsif, status, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
     end
   end
 end
 
 """
-    cgrdh(T, status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
+    cgrdh(T, libsif, status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
 
 The cgrdh subroutine evaluates the gradients of the general
 constraints and of either the objective function f(x) or the
@@ -1807,6 +1851,7 @@ for (cutest_cint_cgrdh, T) in (
   @eval begin
     function cgrdh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1821,13 +1866,13 @@ for (cutest_cint_cgrdh, T) in (
       lh1::StrideOneVector{Cint},
       h_val::Matrix{$T},
     )
-      $cutest_cint_cgrdh(status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
+      $cutest_cint_cgrdh(libsif, status, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
     end
   end
 end
 
 """
-    cdh(T, status, n, m, x, y, lh1, h_val)
+    cdh(T, libsif, status, n, m, x, y, lh1, h_val)
 
 The cdh subroutine evaluates the Hessian matrix of the Lagrangian
 function l(x,y)=f(x)+yTc(x) for the problem decoded from a SIF file by
@@ -1854,6 +1899,7 @@ for (cutest_cdh, T) in
   @eval begin
     function cdh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1862,13 +1908,13 @@ for (cutest_cdh, T) in
       lh1::StrideOneVector{Cint},
       h_val::Matrix{$T},
     )
-      $cutest_cdh(status, n, m, x, y, lh1, h_val)
+      $cutest_cdh(libsif, status, n, m, x, y, lh1, h_val)
     end
   end
 end
 
 """
-    cdhc(T, status, n, m, x, y, lh1, h_val)
+    cdhc(T, libsif, status, n, m, x, y, lh1, h_val)
 
 The cdhc subroutine evaluates the Hessian matrix of the constraint
 part of the Lagrangian function yTc(x) for the problem decoded from a
@@ -1895,6 +1941,7 @@ for (cutest_cdhc, T) in
   @eval begin
     function cdhc(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1903,13 +1950,13 @@ for (cutest_cdhc, T) in
       lh1::StrideOneVector{Cint},
       h_val::Matrix{$T},
     )
-      $cutest_cdhc(status, n, m, x, y, lh1, h_val)
+      $cutest_cdhc(libsif, status, n, m, x, y, lh1, h_val)
     end
   end
 end
 
 """
-    cshp(T, status, n, nnzh, lh, h_row, h_col)
+    cshp(T, libsif, status, n, nnzh, lh, h_row, h_col)
 
 The cshp subroutine evaluates the sparsity pattern of the Hessian of
 the Lagrangian function l(x,y)=f(x)+yTc(x) for the problem, decoded
@@ -1934,6 +1981,7 @@ for (cutest_cshp, T) in
   @eval begin
     function cshp(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       nnzh::StrideOneVector{Cint},
@@ -1941,13 +1989,13 @@ for (cutest_cshp, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_cshp(status, n, nnzh, lh, h_row, h_col)
+      $cutest_cshp(libsif, status, n, nnzh, lh, h_row, h_col)
     end
   end
 end
 
 """
-    csh(T, status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
+    csh(T, libsif, status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
 The csh subroutine evaluates the Hessian of the Lagrangian function
 l(x,y)=f(x)+yTc(x) for the problem decoded from a SIF file by the
@@ -1977,6 +2025,7 @@ for (cutest_csh, T) in
   @eval begin
     function csh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -1988,13 +2037,13 @@ for (cutest_csh, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_csh(status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
+      $cutest_csh(libsif, status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
     end
   end
 end
 
 """
-    cshc(T, status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
+    cshc(T, libsif, status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
 The cshc subroutine evaluates the Hessian matrix of the constraint
 part of the Lagrangian function yTc(x) for the problem decoded from a
@@ -2024,6 +2073,7 @@ for (cutest_cshc, T) in
   @eval begin
     function cshc(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2035,13 +2085,13 @@ for (cutest_cshc, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_cshc(status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
+      $cutest_cshc(libsif, status, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
     end
   end
 end
 
 """
-    ceh(T, status, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+    ceh(T, libsif, status, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
 
 The ceh subroutine evaluates the Hessian matrix of the Lagrangian
 function l(x,y)=f(x)+yTc(x) for the problem decoded into OUTSDIF.d at
@@ -2077,6 +2127,7 @@ for (cutest_ceh, T) in
   @eval begin
     function ceh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2093,6 +2144,7 @@ for (cutest_ceh, T) in
       byrows::StrideOneVector{Cint},
     )
       $cutest_ceh(
+        libsif,
         status,
         n,
         m,
@@ -2113,7 +2165,7 @@ for (cutest_ceh, T) in
 end
 
 """
-    cidh(T, status, n, x, iprob, lh1, h)
+    cidh(T, libsif, status, n, x, iprob, lh1, h)
 
 The cidh subroutine evaluates the Hessian matrix of either the
 objective function or a constraint function for the problem decoded
@@ -2139,6 +2191,7 @@ for (cutest_cidh, T) in
   @eval begin
     function cidh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -2146,13 +2199,13 @@ for (cutest_cidh, T) in
       lh1::StrideOneVector{Cint},
       h::Matrix{$T},
     )
-      $cutest_cidh(status, n, x, iprob, lh1, h)
+      $cutest_cidh(libsif, status, n, x, iprob, lh1, h)
     end
   end
 end
 
 """
-    cish(T, status, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
+    cish(T, libsif, status, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
 
 The cish subroutine evaluates the Hessian of a particular constraint
 function or the objective function for the problem decoded from a SIF
@@ -2181,6 +2234,7 @@ for (cutest_cish, T) in
   @eval begin
     function cish(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       x::StrideOneVector{$T},
@@ -2191,13 +2245,13 @@ for (cutest_cish, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_cish(status, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
+      $cutest_cish(libsif, status, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
     end
   end
 end
 
 """
-    csgrsh(T, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh, h_val, h_row, h_col)
+    csgrsh(T, libsif, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh, h_val, h_row, h_col)
 
 The csgrsh subroutine evaluates the gradients of the general
 constraints, the Hessian matrix of the Lagrangian function
@@ -2238,6 +2292,7 @@ for (cutest_cint_csgrsh, T) in (
   @eval begin
     function csgrsh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2256,6 +2311,7 @@ for (cutest_cint_csgrsh, T) in (
       h_col::StrideOneVector{Cint},
     )
       $cutest_cint_csgrsh(
+        libsif,
         status,
         n,
         m,
@@ -2278,7 +2334,7 @@ for (cutest_cint_csgrsh, T) in (
 end
 
 """
-    csgreh(T, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+    csgreh(T, libsif, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
 
 The csgreh subroutine evaluates both the gradients of the general
 constraint functions and the Hessian matrix of the Lagrangian function
@@ -2326,6 +2382,7 @@ for (cutest_cint_csgreh, T) in (
   @eval begin
     function csgreh(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2348,6 +2405,7 @@ for (cutest_cint_csgreh, T) in (
       byrows::StrideOneVector{Bool},
     )
       $cutest_cint_csgreh(
+        libsif,
         status,
         n,
         m,
@@ -2374,7 +2432,7 @@ for (cutest_cint_csgreh, T) in (
 end
 
 """
-    chprod(T, status, n, m, goth, x, y, vector, result)
+    chprod(T, libsif, status, n, m, goth, x, y, vector, result)
 
 The chprod subroutine forms the product of a vector with the Hessian
 matrix of the Lagrangian function l(x,y)=f(x)+yTc(x) corresponding to
@@ -2405,6 +2463,7 @@ for (cutest_cint_chprod, T) in (
   @eval begin
     function chprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2414,13 +2473,13 @@ for (cutest_cint_chprod, T) in (
       vector::StrideOneVector{$T},
       result::StrideOneVector{$T},
     )
-      $cutest_cint_chprod(status, n, m, goth, x, y, vector, result)
+      $cutest_cint_chprod(libsif, status, n, m, goth, x, y, vector, result)
     end
   end
 end
 
 """
-    cshprod(T, status, n, m, goth, x, y, nnz_vector, index_nz_vector, vector, nnz_result, index_nz_result, result)
+    cshprod(T, libsif, status, n, m, goth, x, y, nnz_vector, index_nz_vector, vector, nnz_result, index_nz_result, result)
 
 The cshprod subroutine forms the product of a sparse vector with the
 Hessian matrix of the Lagrangian function l(x,y)=f(x)+yTc(x)
@@ -2454,6 +2513,7 @@ for (cutest_cshprod, T) in
   @eval begin
     function cshprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2468,6 +2528,7 @@ for (cutest_cshprod, T) in
       result::StrideOneVector{$T},
     )
       $cutest_cshprod(
+        libsif,
         status,
         n,
         m,
@@ -2486,7 +2547,7 @@ for (cutest_cshprod, T) in
 end
 
 """
-    chcprod(T, status, n, m, goth, x, y, vector, result)
+    chcprod(T, libsif, status, n, m, goth, x, y, vector, result)
 
 The chcprod subroutine forms the product of a vector with the Hessian
 matrix of the constraint part of the Lagrangian function yTc(x) of the
@@ -2517,6 +2578,7 @@ for (cutest_cint_chcprod, T) in (
   @eval begin
     function chcprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2526,13 +2588,13 @@ for (cutest_cint_chcprod, T) in (
       vector::StrideOneVector{$T},
       result::StrideOneVector{$T},
     )
-      $cutest_cint_chcprod(status, n, m, goth, x, y, vector, result)
+      $cutest_cint_chcprod(libsif, status, n, m, goth, x, y, vector, result)
     end
   end
 end
 
 """
-    cshcprod(T, status, n, m, goth, x, y, nnz_vector, index_nz_vector, vector, nnz_result, index_nz_result, result)
+    cshcprod(T, libsif, status, n, m, goth, x, y, nnz_vector, index_nz_vector, vector, nnz_result, index_nz_result, result)
 
 The cshcprod subroutine forms the product of a sparse vector with the
 Hessian matrix of the constraint part of the Lagrangian function
@@ -2567,6 +2629,7 @@ for (cutest_cint_cshcprod, T) in (
   @eval begin
     function cshcprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2581,6 +2644,7 @@ for (cutest_cint_cshcprod, T) in (
       result::StrideOneVector{$T},
     )
       $cutest_cint_cshcprod(
+        libsif,
         status,
         n,
         m,
@@ -2599,7 +2663,7 @@ for (cutest_cint_cshcprod, T) in (
 end
 
 """
-    cjprod(T, status, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
+    cjprod(T, libsif, status, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
 
 The cjprod subroutine forms the product of a vector with the Jacobian
 matrix, or with its transpose, of the constraint functions of the
@@ -2632,6 +2696,7 @@ for (cutest_cint_cjprod, T) in (
   @eval begin
     function cjprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2643,13 +2708,13 @@ for (cutest_cint_cjprod, T) in (
       result::StrideOneVector{$T},
       lresult::StrideOneVector{Cint},
     )
-      $cutest_cint_cjprod(status, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
+      $cutest_cint_cjprod(libsif, status, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
     end
   end
 end
 
 """
-    csjprod(T, status, n, m, gotj, jtrans, x, nnz_vector, index_nz_vector, vector, lvector, nnz_result, index_nz_result, result, lresult)
+    csjprod(T, libsif, status, n, m, gotj, jtrans, x, nnz_vector, index_nz_vector, vector, lvector, nnz_result, index_nz_result, result, lresult)
 
 The csjprod subroutine forms the product of a sparse vector with the
 Jacobian matrix, or with its transpose, of the constraint functions of
@@ -2686,6 +2751,7 @@ for (cutest_cint_csjprod, T) in (
   @eval begin
     function csjprod(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2702,6 +2768,7 @@ for (cutest_cint_csjprod, T) in (
       lresult::StrideOneVector{Cint},
     )
       $cutest_cint_csjprod(
+        libsif,
         status,
         n,
         m,
@@ -2722,7 +2789,7 @@ for (cutest_cint_csjprod, T) in (
 end
 
 """
-    cchprods(T, status, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
+    cchprods(T, libsif, status, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
 
 The cchprods subroutine forms the product of a vector with each of the
 Hessian matrix of the constraint functions c(x) corresponding to the
@@ -2755,6 +2822,7 @@ for (cutest_cint_cchprods, T) in (
   @eval begin
     function cchprods(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
@@ -2766,13 +2834,13 @@ for (cutest_cint_cchprods, T) in (
       chp_ind::StrideOneVector{Cint},
       chp_ptr::StrideOneVector{Cint},
     )
-      $cutest_cint_cchprods(status, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
+      $cutest_cint_cchprods(libsif, status, n, m, goth, x, vector, lchp, chp_val, chp_ind, chp_ptr)
     end
   end
 end
 
 """
-    cchprodsp(T, status, m, lchp, chp_ind, chp_ptr)
+    cchprodsp(T, libsif, status, m, lchp, chp_ind, chp_ptr)
 
 The cchprodsp subroutine obtains the sparsity structure used when forming the
 product of a vector with each of the Hessian matrices of the constraint
@@ -2795,19 +2863,20 @@ for (cutest_cchprodsp, T) in (
   @eval begin
     function cchprodsp(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       m::StrideOneVector{Cint},
       lchp::StrideOneVector{Cint},
       chp_ind::StrideOneVector{Cint},
       chp_ptr::StrideOneVector{Cint},
     )
-      $cutest_cchprodsp(status, m, lchp, chp_ind, chp_ptr)
+      $cutest_cchprodsp(libsif, status, m, lchp, chp_ind, chp_ptr)
     end
   end
 end
 
 """
-    uterminate(T, status)
+    uterminate(T, libsif, status)
 
 The uterminate subroutine deallocates all workspace arrays created
 since the last call to usetup.
@@ -2822,14 +2891,14 @@ for (cutest_uterminate, T) in (
   (:cutest_uterminate_q_, :Float128),
 )
   @eval begin
-    function uterminate(::Type{$T}, status::StrideOneVector{Cint})
-      $cutest_uterminate(status)
+    function uterminate(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint})
+      $cutest_uterminate(libsif, status)
     end
   end
 end
 
 """
-    cterminate(T, status)
+    cterminate(T, libsif, status)
 
 The uterminate subroutine deallocates all workspace arrays created
 since the last call to csetup.
@@ -2844,14 +2913,14 @@ for (cutest_cterminate, T) in (
   (:cutest_cterminate_q_, :Float128),
 )
   @eval begin
-    function cterminate(::Type{$T}, status::StrideOneVector{Cint})
-      $cutest_cterminate(status)
+    function cterminate(::Type{$T}, libsif::Ptr{Cvoid}, status::StrideOneVector{Cint})
+      $cutest_cterminate(libsif, status)
     end
   end
 end
 
 """
-    cifn(T, status, n, iprob, x, f)
+    cifn(T, libsif, status, n, iprob, x, f)
 
 The cifn subroutine evaluates the value of either the objective function or a
 constrainted function of the problem decoded from a SIF file by the script
@@ -2870,19 +2939,20 @@ for (cutest_cifn, T) in
   @eval begin
     function cifn(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       iprob::StrideOneVector{Cint},
       x::StrideOneVector{$T},
       f::StrideOneVector{$T},
     )
-      $cutest_cifn(status, n, iprob, x, f)
+      $cutest_cifn(libsif, status, n, iprob, x, f)
     end
   end
 end
 
 """
-    cisgr(T, status, n, iprod, x, nnzg, lg, g_val, g_var)
+    cisgr(T, libsif, status, n, iprod, x, nnzg, lg, g_val, g_var)
 
 The cisgr subroutine evaluates the gradient of either the objective function or
 a constraint function of the problem decoded from a SIF file by the script
@@ -2905,6 +2975,7 @@ for (cutest_cisgr, T) in
   @eval begin
     function cisgr(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       iprod::StrideOneVector{Cint},
@@ -2914,13 +2985,13 @@ for (cutest_cisgr, T) in
       g_val::StrideOneVector{$T},
       g_var::StrideOneVector{Cint},
     )
-      $cutest_cisgr(status, n, iprod, x, nnzg, lg, g_val, g_var)
+      $cutest_cisgr(libsif, status, n, iprod, x, nnzg, lg, g_val, g_var)
     end
   end
 end
 
 """
-    csgrp(T, status, n, nnzj, lj, j_var, j_fun)
+    csgrp(T, libsif, status, n, nnzj, lj, j_var, j_fun)
 
 The csgrp subroutine evaluates sparsity pattern used when storing the gradients
 of the general constraints and of either the objective function or the
@@ -2941,6 +3012,7 @@ for (cutest_csgrp, T) in
   @eval begin
     function csgrp(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       nnzj::StrideOneVector{Cint},
@@ -2948,13 +3020,13 @@ for (cutest_csgrp, T) in
       j_var::StrideOneVector{Cint},
       j_fun::StrideOneVector{Cint},
     )
-      $cutest_csgrp(status, n, nnzj, lj, j_var, j_fun)
+      $cutest_csgrp(libsif, status, n, nnzj, lj, j_var, j_fun)
     end
   end
 end
 
 """
-    cigr(T, status, n, iprob, x, g_val)
+    cigr(T, libsif, status, n, iprob, x, g_val)
 
 The cigr subroutine evaluates the gradient of either the objective function or
 a constraint function of the problem decoded from a SIF file by the script
@@ -2973,19 +3045,20 @@ for (cutest_cigr, T) in
   @eval begin
     function cigr(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       iprob::StrideOneVector{Cint},
       x::StrideOneVector{$T},
       g_val::StrideOneVector{$T},
     )
-      $cutest_cigr(status, n, iprob, x, g_val)
+      $cutest_cigr(libsif, status, n, iprob, x, g_val)
     end
   end
 end
 
 """
-    csgrshp(T, status, n, nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)
+    csgrshp(T, libsif, status, n, nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)
 
 The csgrshp subroutine evaluates sparsity pattern used when storing the
 gradients of the general constraints and of either the objective function or
@@ -3011,6 +3084,7 @@ for (cutest_csgrshp, T) in
   @eval begin
     function csgrshp(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       n::StrideOneVector{Cint},
       nnzj::StrideOneVector{Cint},
@@ -3022,13 +3096,13 @@ for (cutest_csgrshp, T) in
       h_row::StrideOneVector{Cint},
       h_col::StrideOneVector{Cint},
     )
-      $cutest_csgrshp(status, n, nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)
+      $cutest_csgrshp(libsif, status, n, nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)
     end
   end
 end
 
 """
-    csjp(T, status, nnzj, lj, jvar, jcon)
+    csjp(T, libsif, status, nnzj, lj, jvar, jcon)
 
 The csjp subroutine evaluates the sparsity pattern of the Jacobian of the
 constraints for a problem decoded from a SIF file by the script sifdecoder.
@@ -3046,55 +3120,56 @@ for (cutest_csjp, T) in
   @eval begin
     function csjp(
       ::Type{$T},
+      libsif::Ptr{Cvoid},
       status::StrideOneVector{Cint},
       nnzj::StrideOneVector{Cint},
       lj::StrideOneVector{Cint},
       jvar::StrideOneVector{Cint},
       jcon::StrideOneVector{Cint},
     )
-      $cutest_csjp(status, nnzj, lj, jvar, jcon)
+      $cutest_csjp(libsif, status, nnzj, lj, jvar, jcon)
     end
   end
 end
 
 """
-    fopen(T, funit, outsdif, status)
+    fopen(T, libsif, funit, outsdif, status)
 """
 function fopen end
 
 for (fortran_open, T) in
     ((:fortran_open_s_, :Float32), (:fortran_open_, :Float64), (:fortran_open_q_, :Float128))
   @eval begin
-    function fopen(::Type{$T}, funit, outsdif, status)
-      $fortran_open(funit, outsdif, status)
+    function fopen(::Type{$T}, libsif::Ptr{Cvoid}, funit, outsdif, status)
+      $fortran_open(libsif, funit, outsdif, status)
     end
   end
 end
 
 """
-    fclose(T, funit, status)
+    fclose(T, libsif, funit, status)
 """
 function fclose end
 
 for (fortran_close, T) in
     ((:fortran_close_s_, :Float32), (:fortran_close_, :Float64), (:fortran_close_q_, :Float128))
   @eval begin
-    function fclose(::Type{$T}, funit, status)
-      $fortran_close(funit, status)
+    function fclose(::Type{$T}, libsif::Ptr{Cvoid}, funit, status)
+      $fortran_close(libsif, funit, status)
     end
   end
 end
 
 """
-    cconst(T, status, m, c)
+    cconst(T, libsif, status, m, c)
 """
 function cconst end
 
 for (cutest_cconst, T) in
     ((:cutest_cconst_s_, :Float32), (:cutest_cconst_, :Float64), (:cutest_cconst_q_, :Float128))
   @eval begin
-    function cconst(::Type{$T}, status, m, c)
-      $cutest_cconst(status, m, c)
+    function cconst(::Type{$T}, libsif::Ptr{Cvoid}, status, m, c)
+      $cutest_cconst(libsif, status, m, c)
     end
   end
 end

--- a/src/libcutest.jl
+++ b/src/libcutest.jl
@@ -1,48 +1,14 @@
 #! format: off
-function CUTEst_malloc(object, length, s)
-  ptr_CUTEst_malloc = Libdl.dlsym(cutest_lib_double, :CUTEst_malloc)
-  @ccall $ptr_CUTEst_malloc(object::Ptr{Cvoid}, length::Cint, s::Csize_t)::Ptr{Cvoid}
-end
-
-function CUTEst_calloc(object, length, s)
-  ptr_CUTEst_calloc = Libdl.dlsym(cutest_lib_double, :CUTEst_calloc)
-  @ccall $ptr_CUTEst_calloc(object::Ptr{Cvoid}, length::Cint, s::Csize_t)::Ptr{Cvoid}
-end
-
-function CUTEst_realloc(object, length, s)
-  ptr_CUTEst_realloc = Libdl.dlsym(cutest_lib_double, :CUTEst_realloc)
-  @ccall $ptr_CUTEst_realloc(object::Ptr{Cvoid}, length::Cint, s::Csize_t)::Ptr{Cvoid}
-end
-
-function CUTEst_free(object)
-  ptr_CUTEst_free = Libdl.dlsym(cutest_lib_double, :CUTEst_free)
-  @ccall $ptr_CUTEst_free(object::Ptr{Ptr{Cvoid}})::Cvoid
-end
-
-struct VarTypes
-  nbnds::Cint
-  neq::Cint
-  nlin::Cint
-  nrange::Cint
-  nlower::Cint
-  nupper::Cint
-  nineq::Cint
-  nineq_lin::Cint
-  nineq_nlin::Cint
-  neq_lin::Cint
-  neq_nlin::Cint
-end
-
-function cutest_usetup_(status, funit, iout, io_buffer, n, x, bl, bu)
-  ptr_cutest_usetup_ = Libdl.dlsym(cutest_lib_double, :cutest_usetup_)
+function cutest_usetup_(libsif, status, funit, iout, io_buffer, n, x, bl, bu)
+  ptr_cutest_usetup_ = Libdl.dlsym(libsif, :cutest_usetup_)
   @ccall $ptr_cutest_usetup_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                              io_buffer::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, bl::Ptr{Float64},
                              bu::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_csetup_(status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu, equatn,
-                             linear, e_order, l_order, v_order)
-  ptr_cutest_cint_csetup_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_csetup_)
+function cutest_cint_csetup_(libsif, status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu,
+                             equatn, linear, e_order, l_order, v_order)
+  ptr_cutest_cint_csetup_ = Libdl.dlsym(libsif, :cutest_cint_csetup_)
   @ccall $ptr_cutest_cint_csetup_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                                   io_buffer::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                   bl::Ptr{Float64}, bu::Ptr{Float64}, v::Ptr{Float64},
@@ -51,396 +17,400 @@ function cutest_cint_csetup_(status, funit, iout, io_buffer, n, m, x, bl, bu, v,
                                   v_order::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimen_(status, funit, n)
-  ptr_cutest_udimen_ = Libdl.dlsym(cutest_lib_double, :cutest_udimen_)
+function cutest_udimen_(libsif, status, funit, n)
+  ptr_cutest_udimen_ = Libdl.dlsym(libsif, :cutest_udimen_)
   @ccall $ptr_cutest_udimen_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimsh_(status, nnzh)
-  ptr_cutest_udimsh_ = Libdl.dlsym(cutest_lib_double, :cutest_udimsh_)
+function cutest_udimsh_(libsif, status, nnzh)
+  ptr_cutest_udimsh_ = Libdl.dlsym(libsif, :cutest_udimsh_)
   @ccall $ptr_cutest_udimsh_(status::Ptr{Cint}, nnzh::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimse_(status, ne, nzh, nzirnh)
-  ptr_cutest_udimse_ = Libdl.dlsym(cutest_lib_double, :cutest_udimse_)
+function cutest_udimse_(libsif, status, ne, nzh, nzirnh)
+  ptr_cutest_udimse_ = Libdl.dlsym(libsif, :cutest_udimse_)
   @ccall $ptr_cutest_udimse_(status::Ptr{Cint}, ne::Ptr{Cint}, nzh::Ptr{Cint},
                              nzirnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_uvartype_(status, n, ivarty)
-  ptr_cutest_uvartype_ = Libdl.dlsym(cutest_lib_double, :cutest_uvartype_)
+function cutest_uvartype_(libsif, status, n, ivarty)
+  ptr_cutest_uvartype_ = Libdl.dlsym(libsif, :cutest_uvartype_)
   @ccall $ptr_cutest_uvartype_(status::Ptr{Cint}, n::Ptr{Cint}, ivarty::Ptr{Cint})::Cvoid
 end
 
-function cutest_unames_(status, n, pname, vnames)
-  ptr_cutest_unames_ = Libdl.dlsym(cutest_lib_double, :cutest_unames_)
+function cutest_unames_(libsif, status, n, pname, vnames)
+  ptr_cutest_unames_ = Libdl.dlsym(libsif, :cutest_unames_)
   @ccall $ptr_cutest_unames_(status::Ptr{Cint}, n::Ptr{Cint}, pname::Ptr{Cchar},
                              vnames::Ptr{Cchar})::Cvoid
 end
 
-function cutest_ureport_(status, calls, time)
-  ptr_cutest_ureport_ = Libdl.dlsym(cutest_lib_double, :cutest_ureport_)
+function cutest_ureport_(libsif, status, calls, time)
+  ptr_cutest_ureport_ = Libdl.dlsym(libsif, :cutest_ureport_)
   @ccall $ptr_cutest_ureport_(status::Ptr{Cint}, calls::Ptr{Float64}, time::Ptr{Float64})::Cvoid
 end
 
-function cutest_cdimen_(status, funit, n, m)
-  ptr_cutest_cdimen_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimen_)
+function cutest_cdimen_(libsif, status, funit, n, m)
+  ptr_cutest_cdimen_ = Libdl.dlsym(libsif, :cutest_cdimen_)
   @ccall $ptr_cutest_cdimen_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cnoobj_(status, funit, noobj)
-  ptr_cutest_cint_cnoobj_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cnoobj_)
+function cutest_cint_cnoobj_(libsif, status, funit, noobj)
+  ptr_cutest_cint_cnoobj_ = Libdl.dlsym(libsif, :cutest_cint_cnoobj_)
   @ccall $ptr_cutest_cint_cnoobj_(status::Ptr{Cint}, funit::Ptr{Cint}, noobj::Ptr{Bool})::Cvoid
 end
 
-function cutest_cdimsg_(status, nnzg)
-  ptr_cutest_cdimsg_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimsg_)
+function cutest_cdimsg_(libsif, status, nnzg)
+  ptr_cutest_cdimsg_ = Libdl.dlsym(libsif, :cutest_cdimsg_)
   @ccall $ptr_cutest_cdimsg_(status::Ptr{Cint}, nnzg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimsj_(status, nnzj)
-  ptr_cutest_cdimsj_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimsj_)
+function cutest_cdimsj_(libsif, status, nnzj)
+  ptr_cutest_cdimsj_ = Libdl.dlsym(libsif, :cutest_cdimsj_)
   @ccall $ptr_cutest_cdimsj_(status::Ptr{Cint}, nnzj::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimsh_(status, nnzh)
-  ptr_cutest_cdimsh_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimsh_)
+function cutest_cdimsh_(libsif, status, nnzh)
+  ptr_cutest_cdimsh_ = Libdl.dlsym(libsif, :cutest_cdimsh_)
   @ccall $ptr_cutest_cdimsh_(status::Ptr{Cint}, nnzh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimohp_(status, nnzohp)
-  ptr_cutest_cdimohp_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimohp_)
+function cutest_cdimohp_(libsif, status, nnzohp)
+  ptr_cutest_cdimohp_ = Libdl.dlsym(libsif, :cutest_cdimohp_)
   @ccall $ptr_cutest_cdimohp_(status::Ptr{Cint}, nnzohp::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimchp_(status, nnzchp)
-  ptr_cutest_cdimchp_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimchp_)
+function cutest_cdimchp_(libsif, status, nnzchp)
+  ptr_cutest_cdimchp_ = Libdl.dlsym(libsif, :cutest_cdimchp_)
   @ccall $ptr_cutest_cdimchp_(status::Ptr{Cint}, nnzchp::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimse_(status, ne, nzh, nzirnh)
-  ptr_cutest_cdimse_ = Libdl.dlsym(cutest_lib_double, :cutest_cdimse_)
+function cutest_cdimse_(libsif, status, ne, nzh, nzirnh)
+  ptr_cutest_cdimse_ = Libdl.dlsym(libsif, :cutest_cdimse_)
   @ccall $ptr_cutest_cdimse_(status::Ptr{Cint}, ne::Ptr{Cint}, nzh::Ptr{Cint},
                              nzirnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cstats_(status, nonlinear_variables_objective, nonlinear_variables_constraints,
-                        equality_constraints, linear_constraints)
-  ptr_cutest_cstats_ = Libdl.dlsym(cutest_lib_double, :cutest_cstats_)
+function cutest_cstats_(libsif, status, nonlinear_variables_objective,
+                        nonlinear_variables_constraints, equality_constraints, linear_constraints)
+  ptr_cutest_cstats_ = Libdl.dlsym(libsif, :cutest_cstats_)
   @ccall $ptr_cutest_cstats_(status::Ptr{Cint}, nonlinear_variables_objective::Ptr{Cint},
                              nonlinear_variables_constraints::Ptr{Cint},
                              equality_constraints::Ptr{Cint}, linear_constraints::Ptr{Cint})::Cvoid
 end
 
-function cutest_cvartype_(status, n, ivarty)
-  ptr_cutest_cvartype_ = Libdl.dlsym(cutest_lib_double, :cutest_cvartype_)
+function cutest_cvartype_(libsif, status, n, ivarty)
+  ptr_cutest_cvartype_ = Libdl.dlsym(libsif, :cutest_cvartype_)
   @ccall $ptr_cutest_cvartype_(status::Ptr{Cint}, n::Ptr{Cint}, ivarty::Ptr{Cint})::Cvoid
 end
 
-function cutest_cnames_(status, n, m, pname, vnames, gnames)
-  ptr_cutest_cnames_ = Libdl.dlsym(cutest_lib_double, :cutest_cnames_)
+function cutest_cnames_(libsif, status, n, m, pname, vnames, gnames)
+  ptr_cutest_cnames_ = Libdl.dlsym(libsif, :cutest_cnames_)
   @ccall $ptr_cutest_cnames_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, pname::Ptr{Cchar},
                              vnames::Ptr{Cchar}, gnames::Ptr{Cchar})::Cvoid
 end
 
-function cutest_creport_(status, calls, time)
-  ptr_cutest_creport_ = Libdl.dlsym(cutest_lib_double, :cutest_creport_)
+function cutest_creport_(libsif, status, calls, time)
+  ptr_cutest_creport_ = Libdl.dlsym(libsif, :cutest_creport_)
   @ccall $ptr_cutest_creport_(status::Ptr{Cint}, calls::Ptr{Float64}, time::Ptr{Float64})::Cvoid
 end
 
-function cutest_connames_(status, m, gname)
-  ptr_cutest_connames_ = Libdl.dlsym(cutest_lib_double, :cutest_connames_)
+function cutest_connames_(libsif, status, m, gname)
+  ptr_cutest_connames_ = Libdl.dlsym(libsif, :cutest_connames_)
   @ccall $ptr_cutest_connames_(status::Ptr{Cint}, m::Ptr{Cint}, gname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_pname_(status, funit, pname)
-  ptr_cutest_pname_ = Libdl.dlsym(cutest_lib_double, :cutest_pname_)
+function cutest_pname_(libsif, status, funit, pname)
+  ptr_cutest_pname_ = Libdl.dlsym(libsif, :cutest_pname_)
   @ccall $ptr_cutest_pname_(status::Ptr{Cint}, funit::Ptr{Cint}, pname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_probname_(status, pname)
-  ptr_cutest_probname_ = Libdl.dlsym(cutest_lib_double, :cutest_probname_)
+function cutest_probname_(libsif, status, pname)
+  ptr_cutest_probname_ = Libdl.dlsym(libsif, :cutest_probname_)
   @ccall $ptr_cutest_probname_(status::Ptr{Cint}, pname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_varnames_(status, n, vname)
-  ptr_cutest_varnames_ = Libdl.dlsym(cutest_lib_double, :cutest_varnames_)
+function cutest_varnames_(libsif, status, n, vname)
+  ptr_cutest_varnames_ = Libdl.dlsym(libsif, :cutest_varnames_)
   @ccall $ptr_cutest_varnames_(status::Ptr{Cint}, n::Ptr{Cint}, vname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_ufn_(status, n, x, f)
-  ptr_cutest_ufn_ = Libdl.dlsym(cutest_lib_double, :cutest_ufn_)
+function cutest_ufn_(libsif, status, n, x, f)
+  ptr_cutest_ufn_ = Libdl.dlsym(libsif, :cutest_ufn_)
   @ccall $ptr_cutest_ufn_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, f::Ptr{Float64})::Cvoid
 end
 
-function cutest_ugr_(status, n, x, g)
-  ptr_cutest_ugr_ = Libdl.dlsym(cutest_lib_double, :cutest_ugr_)
+function cutest_ugr_(libsif, status, n, x, g)
+  ptr_cutest_ugr_ = Libdl.dlsym(libsif, :cutest_ugr_)
   @ccall $ptr_cutest_ugr_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, g::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_uofg_(status, n, x, f, g, grad)
-  ptr_cutest_cint_uofg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_uofg_)
+function cutest_cint_uofg_(libsif, status, n, x, f, g, grad)
+  ptr_cutest_cint_uofg_ = Libdl.dlsym(libsif, :cutest_cint_uofg_)
   @ccall $ptr_cutest_cint_uofg_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, f::Ptr{Float64},
                                 g::Ptr{Float64}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_udh_(status, n, x, lh1, h)
-  ptr_cutest_udh_ = Libdl.dlsym(cutest_lib_double, :cutest_udh_)
+function cutest_udh_(libsif, status, n, x, lh1, h)
+  ptr_cutest_udh_ = Libdl.dlsym(libsif, :cutest_udh_)
   @ccall $ptr_cutest_udh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, lh1::Ptr{Cint},
                           h::Ptr{Float64})::Cvoid
 end
 
-function cutest_ushp_(status, n, nnzh, lh, irnh, icnh)
-  ptr_cutest_ushp_ = Libdl.dlsym(cutest_lib_double, :cutest_ushp_)
+function cutest_ushp_(libsif, status, n, nnzh, lh, irnh, icnh)
+  ptr_cutest_ushp_ = Libdl.dlsym(libsif, :cutest_ushp_)
   @ccall $ptr_cutest_ushp_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                            irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_ush_(status, n, x, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_ush_ = Libdl.dlsym(cutest_lib_double, :cutest_ush_)
+function cutest_ush_(libsif, status, n, x, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ush_ = Libdl.dlsym(libsif, :cutest_ush_)
   @ccall $ptr_cutest_ush_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, nnzh::Ptr{Cint},
                           lh::Ptr{Cint}, h::Ptr{Float64}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ueh_(status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_ueh_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ueh_)
+function cutest_cint_ueh_(libsif, status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                          byrows)
+  ptr_cutest_cint_ueh_ = Libdl.dlsym(libsif, :cutest_cint_ueh_)
   @ccall $ptr_cutest_cint_ueh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, ne::Ptr{Cint},
                                le::Ptr{Cint}, iprnhi::Ptr{Cint}, iprhi::Ptr{Cint},
                                lirnhi::Ptr{Cint}, irnhi::Ptr{Cint}, lhi::Ptr{Cint},
                                hi::Ptr{Float64}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_ugrdh_(status, n, x, g, lh1, h)
-  ptr_cutest_ugrdh_ = Libdl.dlsym(cutest_lib_double, :cutest_ugrdh_)
+function cutest_ugrdh_(libsif, status, n, x, g, lh1, h)
+  ptr_cutest_ugrdh_ = Libdl.dlsym(libsif, :cutest_ugrdh_)
   @ccall $ptr_cutest_ugrdh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, g::Ptr{Float64},
                             lh1::Ptr{Cint}, h::Ptr{Float64})::Cvoid
 end
 
-function cutest_ugrsh_(status, n, x, g, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_ugrsh_ = Libdl.dlsym(cutest_lib_double, :cutest_ugrsh_)
+function cutest_ugrsh_(libsif, status, n, x, g, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ugrsh_ = Libdl.dlsym(libsif, :cutest_ugrsh_)
   @ccall $ptr_cutest_ugrsh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, g::Ptr{Float64},
                             nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float64}, irnh::Ptr{Cint},
                             icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ugreh_(status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_ugreh_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ugreh_)
+function cutest_cint_ugreh_(libsif, status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                            byrows)
+  ptr_cutest_cint_ugreh_ = Libdl.dlsym(libsif, :cutest_cint_ugreh_)
   @ccall $ptr_cutest_cint_ugreh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, g::Ptr{Float64},
                                  ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint}, iprhi::Ptr{Cint},
                                  lirnhi::Ptr{Cint}, irnhi::Ptr{Cint}, lhi::Ptr{Cint},
                                  hi::Ptr{Float64}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_uhprod_(status, n, goth, x, p, r)
-  ptr_cutest_cint_uhprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_uhprod_)
+function cutest_cint_uhprod_(libsif, status, n, goth, x, p, r)
+  ptr_cutest_cint_uhprod_ = Libdl.dlsym(libsif, :cutest_cint_uhprod_)
   @ccall $ptr_cutest_cint_uhprod_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool}, x::Ptr{Float64},
                                   p::Ptr{Float64}, r::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_ushprod_(status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_ushprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ushprod_)
+function cutest_cint_ushprod_(libsif, status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_ushprod_ = Libdl.dlsym(libsif, :cutest_cint_ushprod_)
   @ccall $ptr_cutest_cint_ushprod_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                    x::Ptr{Float64}, nnzp::Ptr{Cint}, indp::Ptr{Cint},
                                    p::Ptr{Float64}, nnzr::Ptr{Cint}, indr::Ptr{Cint},
                                    r::Ptr{Float64})::Cvoid
 end
 
-function cutest_ubandh_(status, n, x, nsemib, bandh, lbandh, maxsbw)
-  ptr_cutest_ubandh_ = Libdl.dlsym(cutest_lib_double, :cutest_ubandh_)
+function cutest_ubandh_(libsif, status, n, x, nsemib, bandh, lbandh, maxsbw)
+  ptr_cutest_ubandh_ = Libdl.dlsym(libsif, :cutest_ubandh_)
   @ccall $ptr_cutest_ubandh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, nsemib::Ptr{Cint},
                              bandh::Ptr{Float64}, lbandh::Ptr{Cint}, maxsbw::Ptr{Cint})::Cvoid
 end
 
-function cutest_cfn_(status, n, m, x, f, c)
-  ptr_cutest_cfn_ = Libdl.dlsym(cutest_lib_double, :cutest_cfn_)
+function cutest_cfn_(libsif, status, n, m, x, f, c)
+  ptr_cutest_cfn_ = Libdl.dlsym(libsif, :cutest_cfn_)
   @ccall $ptr_cutest_cfn_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                           f::Ptr{Float64}, c::Ptr{Float64})::Cvoid
 end
 
-function cutest_cconst_(status, m, c)
-  ptr_cutest_cconst_ = Libdl.dlsym(cutest_lib_double, :cutest_cconst_)
+function cutest_cconst_(libsif, status, m, c)
+  ptr_cutest_cconst_ = Libdl.dlsym(libsif, :cutest_cconst_)
   @ccall $ptr_cutest_cconst_(status::Ptr{Cint}, m::Ptr{Cint}, c::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_cofg_(status, n, x, f, g, grad)
-  ptr_cutest_cint_cofg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cofg_)
+function cutest_cint_cofg_(libsif, status, n, x, f, g, grad)
+  ptr_cutest_cint_cofg_ = Libdl.dlsym(libsif, :cutest_cint_cofg_)
   @ccall $ptr_cutest_cint_cofg_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, f::Ptr{Float64},
                                 g::Ptr{Float64}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cofsg_(status, n, x, f, nnzg, lg, sg, ivsg, grad)
-  ptr_cutest_cint_cofsg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cofsg_)
+function cutest_cint_cofsg_(libsif, status, n, x, f, nnzg, lg, sg, ivsg, grad)
+  ptr_cutest_cint_cofsg_ = Libdl.dlsym(libsif, :cutest_cint_cofsg_)
   @ccall $ptr_cutest_cint_cofsg_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, f::Ptr{Float64},
                                  nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Float64}, ivsg::Ptr{Cint},
                                  grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccfg_(status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
-  ptr_cutest_cint_ccfg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ccfg_)
+function cutest_cint_ccfg_(libsif, status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+  ptr_cutest_cint_ccfg_ = Libdl.dlsym(libsif, :cutest_cint_ccfg_)
   @ccall $ptr_cutest_cint_ccfg_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                 c::Ptr{Float64}, jtrans::Ptr{Bool}, lcjac1::Ptr{Cint},
                                 lcjac2::Ptr{Cint}, cjac::Ptr{Float64}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_clfg_(status, n, m, x, y, f, g, grad)
-  ptr_cutest_cint_clfg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_clfg_)
+function cutest_cint_clfg_(libsif, status, n, m, x, y, f, g, grad)
+  ptr_cutest_cint_clfg_ = Libdl.dlsym(libsif, :cutest_cint_clfg_)
   @ccall $ptr_cutest_cint_clfg_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                 y::Ptr{Float64}, f::Ptr{Float64}, g::Ptr{Float64},
                                 grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cgr_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
-  ptr_cutest_cint_cgr_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cgr_)
+function cutest_cint_cgr_(libsif, status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
+  ptr_cutest_cint_cgr_ = Libdl.dlsym(libsif, :cutest_cint_cgr_)
   @ccall $ptr_cutest_cint_cgr_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                y::Ptr{Float64}, grlagf::Ptr{Bool}, g::Ptr{Float64},
                                jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
                                cjac::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_csgr_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
-  ptr_cutest_cint_csgr_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_csgr_)
+function cutest_cint_csgr_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
+  ptr_cutest_cint_csgr_ = Libdl.dlsym(libsif, :cutest_cint_csgr_)
   @ccall $ptr_cutest_cint_csgr_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                 y::Ptr{Float64}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                 lcjac::Ptr{Cint}, cjac::Ptr{Float64}, indvar::Ptr{Cint},
                                 indfun::Ptr{Cint})::Cvoid
 end
 
-function cutest_csgrp_(status, n, nnzj, lj, jvar, jcon)
-  ptr_cutest_csgrp_ = Libdl.dlsym(cutest_lib_double, :cutest_csgrp_)
+function cutest_csgrp_(libsif, status, n, nnzj, lj, jvar, jcon)
+  ptr_cutest_csgrp_ = Libdl.dlsym(libsif, :cutest_csgrp_)
   @ccall $ptr_cutest_csgrp_(status::Ptr{Cint}, n::Ptr{Cint}, nnzj::Ptr{Cint}, lj::Ptr{Cint},
                             jvar::Ptr{Cint}, jcon::Ptr{Cint})::Cvoid
 end
 
-function cutest_csjp_(status, nnzj, lj, jvar, jcon)
-  ptr_cutest_csjp_ = Libdl.dlsym(cutest_lib_double, :cutest_csjp_)
+function cutest_csjp_(libsif, status, nnzj, lj, jvar, jcon)
+  ptr_cutest_csjp_ = Libdl.dlsym(libsif, :cutest_csjp_)
   @ccall $ptr_cutest_csjp_(status::Ptr{Cint}, nnzj::Ptr{Cint}, lj::Ptr{Cint}, jvar::Ptr{Cint},
                            jcon::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ccfsg_(status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
-  ptr_cutest_cint_ccfsg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ccfsg_)
+function cutest_cint_ccfsg_(libsif, status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
+  ptr_cutest_cint_ccfsg_ = Libdl.dlsym(libsif, :cutest_cint_ccfsg_)
   @ccall $ptr_cutest_cint_ccfsg_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                  c::Ptr{Float64}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
                                  cjac::Ptr{Float64}, indvar::Ptr{Cint}, indfun::Ptr{Cint},
                                  grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccifg_(status, n, icon, x, ci, gci, grad)
-  ptr_cutest_cint_ccifg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ccifg_)
+function cutest_cint_ccifg_(libsif, status, n, icon, x, ci, gci, grad)
+  ptr_cutest_cint_ccifg_ = Libdl.dlsym(libsif, :cutest_cint_ccifg_)
   @ccall $ptr_cutest_cint_ccifg_(status::Ptr{Cint}, n::Ptr{Cint}, icon::Ptr{Cint}, x::Ptr{Float64},
                                  ci::Ptr{Float64}, gci::Ptr{Float64}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccifsg_(status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
-  ptr_cutest_cint_ccifsg_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ccifsg_)
+function cutest_cint_ccifsg_(libsif, status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
+  ptr_cutest_cint_ccifsg_ = Libdl.dlsym(libsif, :cutest_cint_ccifsg_)
   @ccall $ptr_cutest_cint_ccifsg_(status::Ptr{Cint}, n::Ptr{Cint}, con::Ptr{Cint}, x::Ptr{Float64},
                                   ci::Ptr{Float64}, nnzsgc::Ptr{Cint}, lsgci::Ptr{Cint},
                                   sgci::Ptr{Float64}, ivsgci::Ptr{Cint}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cgrdh_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac, lh1, h)
-  ptr_cutest_cint_cgrdh_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cgrdh_)
+function cutest_cint_cgrdh_(libsif, status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac,
+                            lh1, h)
+  ptr_cutest_cint_cgrdh_ = Libdl.dlsym(libsif, :cutest_cint_cgrdh_)
   @ccall $ptr_cutest_cint_cgrdh_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                  y::Ptr{Float64}, grlagf::Ptr{Bool}, g::Ptr{Float64},
                                  jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
                                  cjac::Ptr{Float64}, lh1::Ptr{Cint}, h::Ptr{Float64})::Cvoid
 end
 
-function cutest_cdh_(status, n, m, x, y, lh1, h)
-  ptr_cutest_cdh_ = Libdl.dlsym(cutest_lib_double, :cutest_cdh_)
+function cutest_cdh_(libsif, status, n, m, x, y, lh1, h)
+  ptr_cutest_cdh_ = Libdl.dlsym(libsif, :cutest_cdh_)
   @ccall $ptr_cutest_cdh_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                           y::Ptr{Float64}, lh1::Ptr{Cint}, h::Ptr{Float64})::Cvoid
 end
 
-function cutest_cdhc_(status, n, m, x, y, lh1, h)
-  ptr_cutest_cdhc_ = Libdl.dlsym(cutest_lib_double, :cutest_cdhc_)
+function cutest_cdhc_(libsif, status, n, m, x, y, lh1, h)
+  ptr_cutest_cdhc_ = Libdl.dlsym(libsif, :cutest_cdhc_)
   @ccall $ptr_cutest_cdhc_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                            y::Ptr{Float64}, lh1::Ptr{Cint}, h::Ptr{Float64})::Cvoid
 end
 
-function cutest_cdhj_(status, n, m, x, y0, y, lh1, h)
-  ptr_cutest_cdhj_ = Libdl.dlsym(cutest_lib_double, :cutest_cdhj_)
+function cutest_cdhj_(libsif, status, n, m, x, y0, y, lh1, h)
+  ptr_cutest_cdhj_ = Libdl.dlsym(libsif, :cutest_cdhj_)
   @ccall $ptr_cutest_cdhj_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                            y0::Ptr{Float64}, y::Ptr{Float64}, lh1::Ptr{Cint},
                            h::Ptr{Float64})::Cvoid
 end
 
-function cutest_cshp_(status, n, nnzh, lh, irnh, icnh)
-  ptr_cutest_cshp_ = Libdl.dlsym(cutest_lib_double, :cutest_cshp_)
+function cutest_cshp_(libsif, status, n, nnzh, lh, irnh, icnh)
+  ptr_cutest_cshp_ = Libdl.dlsym(libsif, :cutest_cshp_)
   @ccall $ptr_cutest_cshp_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                            irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_csh_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_csh_ = Libdl.dlsym(cutest_lib_double, :cutest_csh_)
+function cutest_csh_(libsif, status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_csh_ = Libdl.dlsym(libsif, :cutest_csh_)
   @ccall $ptr_cutest_csh_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                           y::Ptr{Float64}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float64},
                           irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cshc_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cshc_ = Libdl.dlsym(cutest_lib_double, :cutest_cshc_)
+function cutest_cshc_(libsif, status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshc_ = Libdl.dlsym(libsif, :cutest_cshc_)
   @ccall $ptr_cutest_cshc_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                            y::Ptr{Float64}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float64},
                            irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cshj_(status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cshj_ = Libdl.dlsym(cutest_lib_double, :cutest_cshj_)
+function cutest_cshj_(libsif, status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshj_ = Libdl.dlsym(libsif, :cutest_cshj_)
   @ccall $ptr_cutest_cshj_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                            y0::Ptr{Float64}, y::Ptr{Float64}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                            h::Ptr{Float64}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ceh_(status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_ceh_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_ceh_)
+function cutest_cint_ceh_(libsif, status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                          byrows)
+  ptr_cutest_cint_ceh_ = Libdl.dlsym(libsif, :cutest_cint_ceh_)
   @ccall $ptr_cutest_cint_ceh_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                y::Ptr{Float64}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
                                lhi::Ptr{Cint}, hi::Ptr{Float64}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cifn_(status, n, iprob, x, f)
-  ptr_cutest_cifn_ = Libdl.dlsym(cutest_lib_double, :cutest_cifn_)
+function cutest_cifn_(libsif, status, n, iprob, x, f)
+  ptr_cutest_cifn_ = Libdl.dlsym(libsif, :cutest_cifn_)
   @ccall $ptr_cutest_cifn_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float64},
                            f::Ptr{Float64})::Cvoid
 end
 
-function cutest_cigr_(status, n, iprob, x, g)
-  ptr_cutest_cigr_ = Libdl.dlsym(cutest_lib_double, :cutest_cigr_)
+function cutest_cigr_(libsif, status, n, iprob, x, g)
+  ptr_cutest_cigr_ = Libdl.dlsym(libsif, :cutest_cigr_)
   @ccall $ptr_cutest_cigr_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float64},
                            g::Ptr{Float64})::Cvoid
 end
 
-function cutest_cisgr_(status, n, iprob, x, nnzg, lg, sg, ivsg)
-  ptr_cutest_cisgr_ = Libdl.dlsym(cutest_lib_double, :cutest_cisgr_)
+function cutest_cisgr_(libsif, status, n, iprob, x, nnzg, lg, sg, ivsg)
+  ptr_cutest_cisgr_ = Libdl.dlsym(libsif, :cutest_cisgr_)
   @ccall $ptr_cutest_cisgr_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float64},
                             nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Float64},
                             ivsg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cisgrp_(status, n, iprob, nnzg, lg, ivsg)
-  ptr_cutest_cisgrp_ = Libdl.dlsym(cutest_lib_double, :cutest_cisgrp_)
+function cutest_cisgrp_(libsif, status, n, iprob, nnzg, lg, ivsg)
+  ptr_cutest_cisgrp_ = Libdl.dlsym(libsif, :cutest_cisgrp_)
   @ccall $ptr_cutest_cisgrp_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzg::Ptr{Cint},
                              lg::Ptr{Cint}, ivsg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cidh_(status, n, x, iprob, lh1, h)
-  ptr_cutest_cidh_ = Libdl.dlsym(cutest_lib_double, :cutest_cidh_)
+function cutest_cidh_(libsif, status, n, x, iprob, lh1, h)
+  ptr_cutest_cidh_ = Libdl.dlsym(libsif, :cutest_cidh_)
   @ccall $ptr_cutest_cidh_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, iprob::Ptr{Cint},
                            lh1::Ptr{Cint}, h::Ptr{Float64})::Cvoid
 end
 
-function cutest_cish_(status, n, x, iprob, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cish_ = Libdl.dlsym(cutest_lib_double, :cutest_cish_)
+function cutest_cish_(libsif, status, n, x, iprob, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cish_ = Libdl.dlsym(libsif, :cutest_cish_)
   @ccall $ptr_cutest_cish_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float64}, iprob::Ptr{Cint},
                            nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float64}, irnh::Ptr{Cint},
                            icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csgrsh_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, nnzh,
-                             lh, h, irnh, icnh)
-  ptr_cutest_cint_csgrsh_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_csgrsh_)
+function cutest_cint_csgrsh_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun,
+                             nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cint_csgrsh_ = Libdl.dlsym(libsif, :cutest_cint_csgrsh_)
   @ccall $ptr_cutest_cint_csgrsh_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                   y::Ptr{Float64}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                   lcjac::Ptr{Cint}, cjac::Ptr{Float64}, indvar::Ptr{Cint},
@@ -448,16 +418,16 @@ function cutest_cint_csgrsh_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indv
                                   h::Ptr{Float64}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_csgrshp_(status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
-  ptr_cutest_csgrshp_ = Libdl.dlsym(cutest_lib_double, :cutest_csgrshp_)
+function cutest_csgrshp_(libsif, status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
+  ptr_cutest_csgrshp_ = Libdl.dlsym(libsif, :cutest_csgrshp_)
   @ccall $ptr_cutest_csgrshp_(status::Ptr{Cint}, n::Ptr{Cint}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
                               indvar::Ptr{Cint}, indfun::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                               irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csgreh_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, ne, le,
-                             iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_csgreh_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_csgreh_)
+function cutest_cint_csgreh_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun,
+                             ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
+  ptr_cutest_cint_csgreh_ = Libdl.dlsym(libsif, :cutest_cint_csgreh_)
   @ccall $ptr_cutest_cint_csgreh_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float64},
                                   y::Ptr{Float64}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                   lcjac::Ptr{Cint}, cjac::Ptr{Float64}, indvar::Ptr{Cint},
@@ -467,115 +437,116 @@ function cutest_cint_csgreh_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indv
                                   byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_chprod_(status, n, m, goth, x, y, p, q)
-  ptr_cutest_cint_chprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_chprod_)
+function cutest_cint_chprod_(libsif, status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chprod_ = Libdl.dlsym(libsif, :cutest_cint_chprod_)
   @ccall $ptr_cutest_cint_chprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                   x::Ptr{Float64}, y::Ptr{Float64}, p::Ptr{Float64},
                                   q::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_chsprod_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_chsprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_chsprod_)
+function cutest_cint_chsprod_(libsif, status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_chsprod_ = Libdl.dlsym(libsif, :cutest_cint_chsprod_)
   @ccall $ptr_cutest_cint_chsprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                    x::Ptr{Float64}, y::Ptr{Float64}, nnzp::Ptr{Cint},
                                    indp::Ptr{Cint}, p::Ptr{Float64}, nnzr::Ptr{Cint},
                                    indr::Ptr{Cint}, r::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_chcprod_(status, n, m, goth, x, y, p, q)
-  ptr_cutest_cint_chcprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_chcprod_)
+function cutest_cint_chcprod_(libsif, status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chcprod_ = Libdl.dlsym(libsif, :cutest_cint_chcprod_)
   @ccall $ptr_cutest_cint_chcprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                    x::Ptr{Float64}, y::Ptr{Float64}, p::Ptr{Float64},
                                    q::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_cshcprod_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_cshcprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cshcprod_)
+function cutest_cint_cshcprod_(libsif, status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_cshcprod_ = Libdl.dlsym(libsif, :cutest_cint_cshcprod_)
   @ccall $ptr_cutest_cint_cshcprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float64}, y::Ptr{Float64}, nnzp::Ptr{Cint},
                                     indp::Ptr{Cint}, p::Ptr{Float64}, nnzr::Ptr{Cint},
                                     indr::Ptr{Cint}, r::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_chjprod_(status, n, m, goth, x, y0, y, p, q)
-  ptr_cutest_cint_chjprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_chjprod_)
+function cutest_cint_chjprod_(libsif, status, n, m, goth, x, y0, y, p, q)
+  ptr_cutest_cint_chjprod_ = Libdl.dlsym(libsif, :cutest_cint_chjprod_)
   @ccall $ptr_cutest_cint_chjprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                    x::Ptr{Float64}, y0::Ptr{Float64}, y::Ptr{Float64},
                                    p::Ptr{Float64}, q::Ptr{Float64})::Cvoid
 end
 
-function cutest_cint_cjprod_(status, n, m, gotj, jtrans, x, p, lp, r, lr)
-  ptr_cutest_cint_cjprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cjprod_)
+function cutest_cint_cjprod_(libsif, status, n, m, gotj, jtrans, x, p, lp, r, lr)
+  ptr_cutest_cint_cjprod_ = Libdl.dlsym(libsif, :cutest_cint_cjprod_)
   @ccall $ptr_cutest_cint_cjprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
                                   jtrans::Ptr{Bool}, x::Ptr{Float64}, p::Ptr{Float64},
                                   lp::Ptr{Cint}, r::Ptr{Float64}, lr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csjprod_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr, indr, r, lr)
-  ptr_cutest_cint_csjprod_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_csjprod_)
+function cutest_cint_csjprod_(libsif, status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr, indr,
+                              r, lr)
+  ptr_cutest_cint_csjprod_ = Libdl.dlsym(libsif, :cutest_cint_csjprod_)
   @ccall $ptr_cutest_cint_csjprod_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
                                    jtrans::Ptr{Bool}, x::Ptr{Float64}, nnzp::Ptr{Cint},
                                    indp::Ptr{Cint}, p::Ptr{Float64}, lp::Ptr{Cint}, nnzr::Ptr{Cint},
                                    indr::Ptr{Cint}, r::Ptr{Float64}, lr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cchprods_(status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
-  ptr_cutest_cint_cchprods_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cchprods_)
+function cutest_cint_cchprods_(libsif, status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
+  ptr_cutest_cint_cchprods_ = Libdl.dlsym(libsif, :cutest_cint_cchprods_)
   @ccall $ptr_cutest_cint_cchprods_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float64}, p::Ptr{Float64}, lchp::Ptr{Cint},
                                     chpval::Ptr{Float64}, chpind::Ptr{Cint},
                                     chpptr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cchprodsp_(status, m, lchp, chpind, chpptr)
-  ptr_cutest_cchprodsp_ = Libdl.dlsym(cutest_lib_double, :cutest_cchprodsp_)
+function cutest_cchprodsp_(libsif, status, m, lchp, chpind, chpptr)
+  ptr_cutest_cchprodsp_ = Libdl.dlsym(libsif, :cutest_cchprodsp_)
   @ccall $ptr_cutest_cchprodsp_(status::Ptr{Cint}, m::Ptr{Cint}, lchp::Ptr{Cint}, chpind::Ptr{Cint},
                                 chpptr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cohprods_(status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
-  ptr_cutest_cint_cohprods_ = Libdl.dlsym(cutest_lib_double, :cutest_cint_cohprods_)
+function cutest_cint_cohprods_(libsif, status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
+  ptr_cutest_cint_cohprods_ = Libdl.dlsym(libsif, :cutest_cint_cohprods_)
   @ccall $ptr_cutest_cint_cohprods_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float64}, p::Ptr{Float64}, nnzohp::Ptr{Cint},
                                     lohp::Ptr{Cint}, ohpval::Ptr{Float64}, ohpind::Ptr{Cint})::Cvoid
 end
 
-function cutest_cohprodsp_(status, nnzohp, lohp, chpind)
-  ptr_cutest_cohprodsp_ = Libdl.dlsym(cutest_lib_double, :cutest_cohprodsp_)
+function cutest_cohprodsp_(libsif, status, nnzohp, lohp, chpind)
+  ptr_cutest_cohprodsp_ = Libdl.dlsym(libsif, :cutest_cohprodsp_)
   @ccall $ptr_cutest_cohprodsp_(status::Ptr{Cint}, nnzohp::Ptr{Cint}, lohp::Ptr{Cint},
                                 chpind::Ptr{Cint})::Cvoid
 end
 
-function cutest_uterminate_(status)
-  ptr_cutest_uterminate_ = Libdl.dlsym(cutest_lib_double, :cutest_uterminate_)
+function cutest_uterminate_(libsif, status)
+  ptr_cutest_uterminate_ = Libdl.dlsym(libsif, :cutest_uterminate_)
   @ccall $ptr_cutest_uterminate_(status::Ptr{Cint})::Cvoid
 end
 
-function cutest_cterminate_(status)
-  ptr_cutest_cterminate_ = Libdl.dlsym(cutest_lib_double, :cutest_cterminate_)
+function cutest_cterminate_(libsif, status)
+  ptr_cutest_cterminate_ = Libdl.dlsym(libsif, :cutest_cterminate_)
   @ccall $ptr_cutest_cterminate_(status::Ptr{Cint})::Cvoid
 end
 
-function fortran_open_(funit, fname, ierr)
-  ptr_fortran_open_ = Libdl.dlsym(cutest_lib_double, :fortran_open_)
+function fortran_open_(libsif, funit, fname, ierr)
+  ptr_fortran_open_ = Libdl.dlsym(libsif, :fortran_open_)
   @ccall $ptr_fortran_open_(funit::Ptr{Cint}, fname::Ptr{Cchar}, ierr::Ptr{Cint})::Cvoid
 end
 
-function fortran_close_(funit, ierr)
-  ptr_fortran_close_ = Libdl.dlsym(cutest_lib_double, :fortran_close_)
+function fortran_close_(libsif, funit, ierr)
+  ptr_fortran_close_ = Libdl.dlsym(libsif, :fortran_close_)
   @ccall $ptr_fortran_close_(funit::Ptr{Cint}, ierr::Ptr{Cint})::Cvoid
 end
 
-function cutest_usetup_s_(status, funit, iout, io_buffer, n, x, bl, bu)
-  ptr_cutest_usetup_s_ = Libdl.dlsym(cutest_lib_single, :cutest_usetup_s_)
+function cutest_usetup_s_(libsif, status, funit, iout, io_buffer, n, x, bl, bu)
+  ptr_cutest_usetup_s_ = Libdl.dlsym(libsif, :cutest_usetup_s_)
   @ccall $ptr_cutest_usetup_s_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                                io_buffer::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32},
                                bl::Ptr{Float32}, bu::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_csetup_s_(status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu, equatn,
-                               linear, e_order, l_order, v_order)
-  ptr_cutest_cint_csetup_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_csetup_s_)
+function cutest_cint_csetup_s_(libsif, status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu,
+                               equatn, linear, e_order, l_order, v_order)
+  ptr_cutest_cint_csetup_s_ = Libdl.dlsym(libsif, :cutest_cint_csetup_s_)
   @ccall $ptr_cutest_cint_csetup_s_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                                     io_buffer::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
                                     x::Ptr{Float32}, bl::Ptr{Float32}, bu::Ptr{Float32},
@@ -584,404 +555,406 @@ function cutest_cint_csetup_s_(status, funit, iout, io_buffer, n, m, x, bl, bu, 
                                     l_order::Ptr{Cint}, v_order::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimen_s_(status, funit, n)
-  ptr_cutest_udimen_s_ = Libdl.dlsym(cutest_lib_single, :cutest_udimen_s_)
+function cutest_udimen_s_(libsif, status, funit, n)
+  ptr_cutest_udimen_s_ = Libdl.dlsym(libsif, :cutest_udimen_s_)
   @ccall $ptr_cutest_udimen_s_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimsh_s_(status, nnzh)
-  ptr_cutest_udimsh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_udimsh_s_)
+function cutest_udimsh_s_(libsif, status, nnzh)
+  ptr_cutest_udimsh_s_ = Libdl.dlsym(libsif, :cutest_udimsh_s_)
   @ccall $ptr_cutest_udimsh_s_(status::Ptr{Cint}, nnzh::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimse_s_(status, ne, nzh, nzirnh)
-  ptr_cutest_udimse_s_ = Libdl.dlsym(cutest_lib_single, :cutest_udimse_s_)
+function cutest_udimse_s_(libsif, status, ne, nzh, nzirnh)
+  ptr_cutest_udimse_s_ = Libdl.dlsym(libsif, :cutest_udimse_s_)
   @ccall $ptr_cutest_udimse_s_(status::Ptr{Cint}, ne::Ptr{Cint}, nzh::Ptr{Cint},
                                nzirnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_uvartype_s_(status, n, ivarty)
-  ptr_cutest_uvartype_s_ = Libdl.dlsym(cutest_lib_single, :cutest_uvartype_s_)
+function cutest_uvartype_s_(libsif, status, n, ivarty)
+  ptr_cutest_uvartype_s_ = Libdl.dlsym(libsif, :cutest_uvartype_s_)
   @ccall $ptr_cutest_uvartype_s_(status::Ptr{Cint}, n::Ptr{Cint}, ivarty::Ptr{Cint})::Cvoid
 end
 
-function cutest_unames_s_(status, n, pname, vnames)
-  ptr_cutest_unames_s_ = Libdl.dlsym(cutest_lib_single, :cutest_unames_s_)
+function cutest_unames_s_(libsif, status, n, pname, vnames)
+  ptr_cutest_unames_s_ = Libdl.dlsym(libsif, :cutest_unames_s_)
   @ccall $ptr_cutest_unames_s_(status::Ptr{Cint}, n::Ptr{Cint}, pname::Ptr{Cchar},
                                vnames::Ptr{Cchar})::Cvoid
 end
 
-function cutest_ureport_s_(status, calls, time)
-  ptr_cutest_ureport_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ureport_s_)
+function cutest_ureport_s_(libsif, status, calls, time)
+  ptr_cutest_ureport_s_ = Libdl.dlsym(libsif, :cutest_ureport_s_)
   @ccall $ptr_cutest_ureport_s_(status::Ptr{Cint}, calls::Ptr{Float32}, time::Ptr{Float32})::Cvoid
 end
 
-function cutest_cdimen_s_(status, funit, n, m)
-  ptr_cutest_cdimen_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimen_s_)
+function cutest_cdimen_s_(libsif, status, funit, n, m)
+  ptr_cutest_cdimen_s_ = Libdl.dlsym(libsif, :cutest_cdimen_s_)
   @ccall $ptr_cutest_cdimen_s_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint},
                                m::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cnoobj_s_(status, funit, noobj)
-  ptr_cutest_cint_cnoobj_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cnoobj_s_)
+function cutest_cint_cnoobj_s_(libsif, status, funit, noobj)
+  ptr_cutest_cint_cnoobj_s_ = Libdl.dlsym(libsif, :cutest_cint_cnoobj_s_)
   @ccall $ptr_cutest_cint_cnoobj_s_(status::Ptr{Cint}, funit::Ptr{Cint}, noobj::Ptr{Bool})::Cvoid
 end
 
-function cutest_cdimsg_s_(status, nnzg)
-  ptr_cutest_cdimsg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimsg_s_)
+function cutest_cdimsg_s_(libsif, status, nnzg)
+  ptr_cutest_cdimsg_s_ = Libdl.dlsym(libsif, :cutest_cdimsg_s_)
   @ccall $ptr_cutest_cdimsg_s_(status::Ptr{Cint}, nnzg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimsj_s_(status, nnzj)
-  ptr_cutest_cdimsj_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimsj_s_)
+function cutest_cdimsj_s_(libsif, status, nnzj)
+  ptr_cutest_cdimsj_s_ = Libdl.dlsym(libsif, :cutest_cdimsj_s_)
   @ccall $ptr_cutest_cdimsj_s_(status::Ptr{Cint}, nnzj::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimsh_s_(status, nnzh)
-  ptr_cutest_cdimsh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimsh_s_)
+function cutest_cdimsh_s_(libsif, status, nnzh)
+  ptr_cutest_cdimsh_s_ = Libdl.dlsym(libsif, :cutest_cdimsh_s_)
   @ccall $ptr_cutest_cdimsh_s_(status::Ptr{Cint}, nnzh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimohp_s_(status, nnzohp)
-  ptr_cutest_cdimohp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimohp_s_)
+function cutest_cdimohp_s_(libsif, status, nnzohp)
+  ptr_cutest_cdimohp_s_ = Libdl.dlsym(libsif, :cutest_cdimohp_s_)
   @ccall $ptr_cutest_cdimohp_s_(status::Ptr{Cint}, nnzohp::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimchp_s_(status, nnzchp)
-  ptr_cutest_cdimchp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimchp_s_)
+function cutest_cdimchp_s_(libsif, status, nnzchp)
+  ptr_cutest_cdimchp_s_ = Libdl.dlsym(libsif, :cutest_cdimchp_s_)
   @ccall $ptr_cutest_cdimchp_s_(status::Ptr{Cint}, nnzchp::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimse_s_(status, ne, nzh, nzirnh)
-  ptr_cutest_cdimse_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdimse_s_)
+function cutest_cdimse_s_(libsif, status, ne, nzh, nzirnh)
+  ptr_cutest_cdimse_s_ = Libdl.dlsym(libsif, :cutest_cdimse_s_)
   @ccall $ptr_cutest_cdimse_s_(status::Ptr{Cint}, ne::Ptr{Cint}, nzh::Ptr{Cint},
                                nzirnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cstats_s_(status, nonlinear_variables_objective, nonlinear_variables_constraints,
-                          equality_constraints, linear_constraints)
-  ptr_cutest_cstats_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cstats_s_)
+function cutest_cstats_s_(libsif, status, nonlinear_variables_objective,
+                          nonlinear_variables_constraints, equality_constraints, linear_constraints)
+  ptr_cutest_cstats_s_ = Libdl.dlsym(libsif, :cutest_cstats_s_)
   @ccall $ptr_cutest_cstats_s_(status::Ptr{Cint}, nonlinear_variables_objective::Ptr{Cint},
                                nonlinear_variables_constraints::Ptr{Cint},
                                equality_constraints::Ptr{Cint},
                                linear_constraints::Ptr{Cint})::Cvoid
 end
 
-function cutest_cvartype_s_(status, n, ivarty)
-  ptr_cutest_cvartype_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cvartype_s_)
+function cutest_cvartype_s_(libsif, status, n, ivarty)
+  ptr_cutest_cvartype_s_ = Libdl.dlsym(libsif, :cutest_cvartype_s_)
   @ccall $ptr_cutest_cvartype_s_(status::Ptr{Cint}, n::Ptr{Cint}, ivarty::Ptr{Cint})::Cvoid
 end
 
-function cutest_cnames_s_(status, n, m, pname, vnames, gnames)
-  ptr_cutest_cnames_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cnames_s_)
+function cutest_cnames_s_(libsif, status, n, m, pname, vnames, gnames)
+  ptr_cutest_cnames_s_ = Libdl.dlsym(libsif, :cutest_cnames_s_)
   @ccall $ptr_cutest_cnames_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, pname::Ptr{Cchar},
                                vnames::Ptr{Cchar}, gnames::Ptr{Cchar})::Cvoid
 end
 
-function cutest_creport_s_(status, calls, time)
-  ptr_cutest_creport_s_ = Libdl.dlsym(cutest_lib_single, :cutest_creport_s_)
+function cutest_creport_s_(libsif, status, calls, time)
+  ptr_cutest_creport_s_ = Libdl.dlsym(libsif, :cutest_creport_s_)
   @ccall $ptr_cutest_creport_s_(status::Ptr{Cint}, calls::Ptr{Float32}, time::Ptr{Float32})::Cvoid
 end
 
-function cutest_connames_s_(status, m, gname)
-  ptr_cutest_connames_s_ = Libdl.dlsym(cutest_lib_single, :cutest_connames_s_)
+function cutest_connames_s_(libsif, status, m, gname)
+  ptr_cutest_connames_s_ = Libdl.dlsym(libsif, :cutest_connames_s_)
   @ccall $ptr_cutest_connames_s_(status::Ptr{Cint}, m::Ptr{Cint}, gname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_pname_s_(status, funit, pname)
-  ptr_cutest_pname_s_ = Libdl.dlsym(cutest_lib_single, :cutest_pname_s_)
+function cutest_pname_s_(libsif, status, funit, pname)
+  ptr_cutest_pname_s_ = Libdl.dlsym(libsif, :cutest_pname_s_)
   @ccall $ptr_cutest_pname_s_(status::Ptr{Cint}, funit::Ptr{Cint}, pname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_probname_s_(status, pname)
-  ptr_cutest_probname_s_ = Libdl.dlsym(cutest_lib_single, :cutest_probname_s_)
+function cutest_probname_s_(libsif, status, pname)
+  ptr_cutest_probname_s_ = Libdl.dlsym(libsif, :cutest_probname_s_)
   @ccall $ptr_cutest_probname_s_(status::Ptr{Cint}, pname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_varnames_s_(status, n, vname)
-  ptr_cutest_varnames_s_ = Libdl.dlsym(cutest_lib_single, :cutest_varnames_s_)
+function cutest_varnames_s_(libsif, status, n, vname)
+  ptr_cutest_varnames_s_ = Libdl.dlsym(libsif, :cutest_varnames_s_)
   @ccall $ptr_cutest_varnames_s_(status::Ptr{Cint}, n::Ptr{Cint}, vname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_ufn_s_(status, n, x, f)
-  ptr_cutest_ufn_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ufn_s_)
+function cutest_ufn_s_(libsif, status, n, x, f)
+  ptr_cutest_ufn_s_ = Libdl.dlsym(libsif, :cutest_ufn_s_)
   @ccall $ptr_cutest_ufn_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32},
                             f::Ptr{Float32})::Cvoid
 end
 
-function cutest_ugr_s_(status, n, x, g)
-  ptr_cutest_ugr_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ugr_s_)
+function cutest_ugr_s_(libsif, status, n, x, g)
+  ptr_cutest_ugr_s_ = Libdl.dlsym(libsif, :cutest_ugr_s_)
   @ccall $ptr_cutest_ugr_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32},
                             g::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_uofg_s_(status, n, x, f, g, grad)
-  ptr_cutest_cint_uofg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_uofg_s_)
+function cutest_cint_uofg_s_(libsif, status, n, x, f, g, grad)
+  ptr_cutest_cint_uofg_s_ = Libdl.dlsym(libsif, :cutest_cint_uofg_s_)
   @ccall $ptr_cutest_cint_uofg_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, f::Ptr{Float32},
                                   g::Ptr{Float32}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_udh_s_(status, n, x, lh1, h)
-  ptr_cutest_udh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_udh_s_)
+function cutest_udh_s_(libsif, status, n, x, lh1, h)
+  ptr_cutest_udh_s_ = Libdl.dlsym(libsif, :cutest_udh_s_)
   @ccall $ptr_cutest_udh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, lh1::Ptr{Cint},
                             h::Ptr{Float32})::Cvoid
 end
 
-function cutest_ushp_s_(status, n, nnzh, lh, irnh, icnh)
-  ptr_cutest_ushp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ushp_s_)
+function cutest_ushp_s_(libsif, status, n, nnzh, lh, irnh, icnh)
+  ptr_cutest_ushp_s_ = Libdl.dlsym(libsif, :cutest_ushp_s_)
   @ccall $ptr_cutest_ushp_s_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_ush_s_(status, n, x, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_ush_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ush_s_)
+function cutest_ush_s_(libsif, status, n, x, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ush_s_ = Libdl.dlsym(libsif, :cutest_ush_s_)
   @ccall $ptr_cutest_ush_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, nnzh::Ptr{Cint},
                             lh::Ptr{Cint}, h::Ptr{Float32}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ueh_s_(status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_ueh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ueh_s_)
+function cutest_cint_ueh_s_(libsif, status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                            byrows)
+  ptr_cutest_cint_ueh_s_ = Libdl.dlsym(libsif, :cutest_cint_ueh_s_)
   @ccall $ptr_cutest_cint_ueh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, ne::Ptr{Cint},
                                  le::Ptr{Cint}, iprnhi::Ptr{Cint}, iprhi::Ptr{Cint},
                                  lirnhi::Ptr{Cint}, irnhi::Ptr{Cint}, lhi::Ptr{Cint},
                                  hi::Ptr{Float32}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_ugrdh_s_(status, n, x, g, lh1, h)
-  ptr_cutest_ugrdh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ugrdh_s_)
+function cutest_ugrdh_s_(libsif, status, n, x, g, lh1, h)
+  ptr_cutest_ugrdh_s_ = Libdl.dlsym(libsif, :cutest_ugrdh_s_)
   @ccall $ptr_cutest_ugrdh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, g::Ptr{Float32},
                               lh1::Ptr{Cint}, h::Ptr{Float32})::Cvoid
 end
 
-function cutest_ugrsh_s_(status, n, x, g, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_ugrsh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ugrsh_s_)
+function cutest_ugrsh_s_(libsif, status, n, x, g, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ugrsh_s_ = Libdl.dlsym(libsif, :cutest_ugrsh_s_)
   @ccall $ptr_cutest_ugrsh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, g::Ptr{Float32},
                               nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float32}, irnh::Ptr{Cint},
                               icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ugreh_s_(status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
-                              byrows)
-  ptr_cutest_cint_ugreh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ugreh_s_)
+function cutest_cint_ugreh_s_(libsif, status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi,
+                              hi, byrows)
+  ptr_cutest_cint_ugreh_s_ = Libdl.dlsym(libsif, :cutest_cint_ugreh_s_)
   @ccall $ptr_cutest_cint_ugreh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32},
                                    g::Ptr{Float32}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                    iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
                                    lhi::Ptr{Cint}, hi::Ptr{Float32}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_uhprod_s_(status, n, goth, x, p, r)
-  ptr_cutest_cint_uhprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_uhprod_s_)
+function cutest_cint_uhprod_s_(libsif, status, n, goth, x, p, r)
+  ptr_cutest_cint_uhprod_s_ = Libdl.dlsym(libsif, :cutest_cint_uhprod_s_)
   @ccall $ptr_cutest_cint_uhprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float32}, p::Ptr{Float32}, r::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_ushprod_s_(status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_ushprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ushprod_s_)
+function cutest_cint_ushprod_s_(libsif, status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_ushprod_s_ = Libdl.dlsym(libsif, :cutest_cint_ushprod_s_)
   @ccall $ptr_cutest_cint_ushprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float32}, nnzp::Ptr{Cint}, indp::Ptr{Cint},
                                      p::Ptr{Float32}, nnzr::Ptr{Cint}, indr::Ptr{Cint},
                                      r::Ptr{Float32})::Cvoid
 end
 
-function cutest_ubandh_s_(status, n, x, nsemib, bandh, lbandh, maxsbw)
-  ptr_cutest_ubandh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_ubandh_s_)
+function cutest_ubandh_s_(libsif, status, n, x, nsemib, bandh, lbandh, maxsbw)
+  ptr_cutest_ubandh_s_ = Libdl.dlsym(libsif, :cutest_ubandh_s_)
   @ccall $ptr_cutest_ubandh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, nsemib::Ptr{Cint},
                                bandh::Ptr{Float32}, lbandh::Ptr{Cint}, maxsbw::Ptr{Cint})::Cvoid
 end
 
-function cutest_cfn_s_(status, n, m, x, f, c)
-  ptr_cutest_cfn_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cfn_s_)
+function cutest_cfn_s_(libsif, status, n, m, x, f, c)
+  ptr_cutest_cfn_s_ = Libdl.dlsym(libsif, :cutest_cfn_s_)
   @ccall $ptr_cutest_cfn_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                             f::Ptr{Float32}, c::Ptr{Float32})::Cvoid
 end
 
-function cutest_cconst_s_(status, m, c)
-  ptr_cutest_cconst_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cconst_s_)
+function cutest_cconst_s_(libsif, status, m, c)
+  ptr_cutest_cconst_s_ = Libdl.dlsym(libsif, :cutest_cconst_s_)
   @ccall $ptr_cutest_cconst_s_(status::Ptr{Cint}, m::Ptr{Cint}, c::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_cofg_s_(status, n, x, f, g, grad)
-  ptr_cutest_cint_cofg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cofg_s_)
+function cutest_cint_cofg_s_(libsif, status, n, x, f, g, grad)
+  ptr_cutest_cint_cofg_s_ = Libdl.dlsym(libsif, :cutest_cint_cofg_s_)
   @ccall $ptr_cutest_cint_cofg_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, f::Ptr{Float32},
                                   g::Ptr{Float32}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cofsg_s_(status, n, x, f, nnzg, lg, sg, ivsg, grad)
-  ptr_cutest_cint_cofsg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cofsg_s_)
+function cutest_cint_cofsg_s_(libsif, status, n, x, f, nnzg, lg, sg, ivsg, grad)
+  ptr_cutest_cint_cofsg_s_ = Libdl.dlsym(libsif, :cutest_cint_cofsg_s_)
   @ccall $ptr_cutest_cint_cofsg_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32},
                                    f::Ptr{Float32}, nnzg::Ptr{Cint}, lg::Ptr{Cint},
                                    sg::Ptr{Float32}, ivsg::Ptr{Cint}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccfg_s_(status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
-  ptr_cutest_cint_ccfg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ccfg_s_)
+function cutest_cint_ccfg_s_(libsif, status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+  ptr_cutest_cint_ccfg_s_ = Libdl.dlsym(libsif, :cutest_cint_ccfg_s_)
   @ccall $ptr_cutest_cint_ccfg_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                   c::Ptr{Float32}, jtrans::Ptr{Bool}, lcjac1::Ptr{Cint},
                                   lcjac2::Ptr{Cint}, cjac::Ptr{Float32}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_clfg_s_(status, n, m, x, y, f, g, grad)
-  ptr_cutest_cint_clfg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_clfg_s_)
+function cutest_cint_clfg_s_(libsif, status, n, m, x, y, f, g, grad)
+  ptr_cutest_cint_clfg_s_ = Libdl.dlsym(libsif, :cutest_cint_clfg_s_)
   @ccall $ptr_cutest_cint_clfg_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                   y::Ptr{Float32}, f::Ptr{Float32}, g::Ptr{Float32},
                                   grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cgr_s_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
-  ptr_cutest_cint_cgr_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cgr_s_)
+function cutest_cint_cgr_s_(libsif, status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
+  ptr_cutest_cint_cgr_s_ = Libdl.dlsym(libsif, :cutest_cint_cgr_s_)
   @ccall $ptr_cutest_cint_cgr_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                  y::Ptr{Float32}, grlagf::Ptr{Bool}, g::Ptr{Float32},
                                  jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
                                  cjac::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_csgr_s_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
-  ptr_cutest_cint_csgr_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_csgr_s_)
+function cutest_cint_csgr_s_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
+  ptr_cutest_cint_csgr_s_ = Libdl.dlsym(libsif, :cutest_cint_csgr_s_)
   @ccall $ptr_cutest_cint_csgr_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                   y::Ptr{Float32}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                   lcjac::Ptr{Cint}, cjac::Ptr{Float32}, indvar::Ptr{Cint},
                                   indfun::Ptr{Cint})::Cvoid
 end
 
-function cutest_csgrp_s_(status, n, nnzj, lj, jvar, jcon)
-  ptr_cutest_csgrp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_csgrp_s_)
+function cutest_csgrp_s_(libsif, status, n, nnzj, lj, jvar, jcon)
+  ptr_cutest_csgrp_s_ = Libdl.dlsym(libsif, :cutest_csgrp_s_)
   @ccall $ptr_cutest_csgrp_s_(status::Ptr{Cint}, n::Ptr{Cint}, nnzj::Ptr{Cint}, lj::Ptr{Cint},
                               jvar::Ptr{Cint}, jcon::Ptr{Cint})::Cvoid
 end
 
-function cutest_csjp_s_(status, nnzj, lj, jvar, jcon)
-  ptr_cutest_csjp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_csjp_s_)
+function cutest_csjp_s_(libsif, status, nnzj, lj, jvar, jcon)
+  ptr_cutest_csjp_s_ = Libdl.dlsym(libsif, :cutest_csjp_s_)
   @ccall $ptr_cutest_csjp_s_(status::Ptr{Cint}, nnzj::Ptr{Cint}, lj::Ptr{Cint}, jvar::Ptr{Cint},
                              jcon::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ccfsg_s_(status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
-  ptr_cutest_cint_ccfsg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ccfsg_s_)
+function cutest_cint_ccfsg_s_(libsif, status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
+  ptr_cutest_cint_ccfsg_s_ = Libdl.dlsym(libsif, :cutest_cint_ccfsg_s_)
   @ccall $ptr_cutest_cint_ccfsg_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                    c::Ptr{Float32}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
                                    cjac::Ptr{Float32}, indvar::Ptr{Cint}, indfun::Ptr{Cint},
                                    grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccifg_s_(status, n, icon, x, ci, gci, grad)
-  ptr_cutest_cint_ccifg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ccifg_s_)
+function cutest_cint_ccifg_s_(libsif, status, n, icon, x, ci, gci, grad)
+  ptr_cutest_cint_ccifg_s_ = Libdl.dlsym(libsif, :cutest_cint_ccifg_s_)
   @ccall $ptr_cutest_cint_ccifg_s_(status::Ptr{Cint}, n::Ptr{Cint}, icon::Ptr{Cint},
                                    x::Ptr{Float32}, ci::Ptr{Float32}, gci::Ptr{Float32},
                                    grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccifsg_s_(status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
-  ptr_cutest_cint_ccifsg_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ccifsg_s_)
+function cutest_cint_ccifsg_s_(libsif, status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
+  ptr_cutest_cint_ccifsg_s_ = Libdl.dlsym(libsif, :cutest_cint_ccifsg_s_)
   @ccall $ptr_cutest_cint_ccifsg_s_(status::Ptr{Cint}, n::Ptr{Cint}, con::Ptr{Cint},
                                     x::Ptr{Float32}, ci::Ptr{Float32}, nnzsgc::Ptr{Cint},
                                     lsgci::Ptr{Cint}, sgci::Ptr{Float32}, ivsgci::Ptr{Cint},
                                     grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cgrdh_s_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac, lh1, h)
-  ptr_cutest_cint_cgrdh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cgrdh_s_)
+function cutest_cint_cgrdh_s_(libsif, status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac,
+                              lh1, h)
+  ptr_cutest_cint_cgrdh_s_ = Libdl.dlsym(libsif, :cutest_cint_cgrdh_s_)
   @ccall $ptr_cutest_cint_cgrdh_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                    y::Ptr{Float32}, grlagf::Ptr{Bool}, g::Ptr{Float32},
                                    jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
                                    cjac::Ptr{Float32}, lh1::Ptr{Cint}, h::Ptr{Float32})::Cvoid
 end
 
-function cutest_cdh_s_(status, n, m, x, y, lh1, h)
-  ptr_cutest_cdh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdh_s_)
+function cutest_cdh_s_(libsif, status, n, m, x, y, lh1, h)
+  ptr_cutest_cdh_s_ = Libdl.dlsym(libsif, :cutest_cdh_s_)
   @ccall $ptr_cutest_cdh_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                             y::Ptr{Float32}, lh1::Ptr{Cint}, h::Ptr{Float32})::Cvoid
 end
 
-function cutest_cdhc_s_(status, n, m, x, y, lh1, h)
-  ptr_cutest_cdhc_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdhc_s_)
+function cutest_cdhc_s_(libsif, status, n, m, x, y, lh1, h)
+  ptr_cutest_cdhc_s_ = Libdl.dlsym(libsif, :cutest_cdhc_s_)
   @ccall $ptr_cutest_cdhc_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                              y::Ptr{Float32}, lh1::Ptr{Cint}, h::Ptr{Float32})::Cvoid
 end
 
-function cutest_cdhj_s_(status, n, m, x, y0, y, lh1, h)
-  ptr_cutest_cdhj_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cdhj_s_)
+function cutest_cdhj_s_(libsif, status, n, m, x, y0, y, lh1, h)
+  ptr_cutest_cdhj_s_ = Libdl.dlsym(libsif, :cutest_cdhj_s_)
   @ccall $ptr_cutest_cdhj_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                              y0::Ptr{Float32}, y::Ptr{Float32}, lh1::Ptr{Cint},
                              h::Ptr{Float32})::Cvoid
 end
 
-function cutest_cshp_s_(status, n, nnzh, lh, irnh, icnh)
-  ptr_cutest_cshp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cshp_s_)
+function cutest_cshp_s_(libsif, status, n, nnzh, lh, irnh, icnh)
+  ptr_cutest_cshp_s_ = Libdl.dlsym(libsif, :cutest_cshp_s_)
   @ccall $ptr_cutest_cshp_s_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_csh_s_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_csh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_csh_s_)
+function cutest_csh_s_(libsif, status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_csh_s_ = Libdl.dlsym(libsif, :cutest_csh_s_)
   @ccall $ptr_cutest_csh_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                             y::Ptr{Float32}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float32},
                             irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cshc_s_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cshc_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cshc_s_)
+function cutest_cshc_s_(libsif, status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshc_s_ = Libdl.dlsym(libsif, :cutest_cshc_s_)
   @ccall $ptr_cutest_cshc_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                              y::Ptr{Float32}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float32},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cshj_s_(status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cshj_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cshj_s_)
+function cutest_cshj_s_(libsif, status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshj_s_ = Libdl.dlsym(libsif, :cutest_cshj_s_)
   @ccall $ptr_cutest_cshj_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                              y0::Ptr{Float32}, y::Ptr{Float32}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              h::Ptr{Float32}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ceh_s_(status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
-                            byrows)
-  ptr_cutest_cint_ceh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_ceh_s_)
+function cutest_cint_ceh_s_(libsif, status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi,
+                            hi, byrows)
+  ptr_cutest_cint_ceh_s_ = Libdl.dlsym(libsif, :cutest_cint_ceh_s_)
   @ccall $ptr_cutest_cint_ceh_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                  y::Ptr{Float32}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                  iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
                                  lhi::Ptr{Cint}, hi::Ptr{Float32}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cifn_s_(status, n, iprob, x, f)
-  ptr_cutest_cifn_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cifn_s_)
+function cutest_cifn_s_(libsif, status, n, iprob, x, f)
+  ptr_cutest_cifn_s_ = Libdl.dlsym(libsif, :cutest_cifn_s_)
   @ccall $ptr_cutest_cifn_s_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float32},
                              f::Ptr{Float32})::Cvoid
 end
 
-function cutest_cigr_s_(status, n, iprob, x, g)
-  ptr_cutest_cigr_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cigr_s_)
+function cutest_cigr_s_(libsif, status, n, iprob, x, g)
+  ptr_cutest_cigr_s_ = Libdl.dlsym(libsif, :cutest_cigr_s_)
   @ccall $ptr_cutest_cigr_s_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float32},
                              g::Ptr{Float32})::Cvoid
 end
 
-function cutest_cisgr_s_(status, n, iprob, x, nnzg, lg, sg, ivsg)
-  ptr_cutest_cisgr_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cisgr_s_)
+function cutest_cisgr_s_(libsif, status, n, iprob, x, nnzg, lg, sg, ivsg)
+  ptr_cutest_cisgr_s_ = Libdl.dlsym(libsif, :cutest_cisgr_s_)
   @ccall $ptr_cutest_cisgr_s_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float32},
                               nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Float32},
                               ivsg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cisgrp_s_(status, n, iprob, nnzg, lg, ivsg)
-  ptr_cutest_cisgrp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cisgrp_s_)
+function cutest_cisgrp_s_(libsif, status, n, iprob, nnzg, lg, ivsg)
+  ptr_cutest_cisgrp_s_ = Libdl.dlsym(libsif, :cutest_cisgrp_s_)
   @ccall $ptr_cutest_cisgrp_s_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzg::Ptr{Cint},
                                lg::Ptr{Cint}, ivsg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cidh_s_(status, n, x, iprob, lh1, h)
-  ptr_cutest_cidh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cidh_s_)
+function cutest_cidh_s_(libsif, status, n, x, iprob, lh1, h)
+  ptr_cutest_cidh_s_ = Libdl.dlsym(libsif, :cutest_cidh_s_)
   @ccall $ptr_cutest_cidh_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, iprob::Ptr{Cint},
                              lh1::Ptr{Cint}, h::Ptr{Float32})::Cvoid
 end
 
-function cutest_cish_s_(status, n, x, iprob, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cish_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cish_s_)
+function cutest_cish_s_(libsif, status, n, x, iprob, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cish_s_ = Libdl.dlsym(libsif, :cutest_cish_s_)
   @ccall $ptr_cutest_cish_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, iprob::Ptr{Cint},
                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float32}, irnh::Ptr{Cint},
                              icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csgrsh_s_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, nnzh,
-                               lh, h, irnh, icnh)
-  ptr_cutest_cint_csgrsh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_csgrsh_s_)
+function cutest_cint_csgrsh_s_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar,
+                               indfun, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cint_csgrsh_s_ = Libdl.dlsym(libsif, :cutest_cint_csgrsh_s_)
   @ccall $ptr_cutest_cint_csgrsh_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                     y::Ptr{Float32}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                     lcjac::Ptr{Cint}, cjac::Ptr{Float32}, indvar::Ptr{Cint},
@@ -989,16 +962,16 @@ function cutest_cint_csgrsh_s_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, in
                                     h::Ptr{Float32}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_csgrshp_s_(status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
-  ptr_cutest_csgrshp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_csgrshp_s_)
+function cutest_csgrshp_s_(libsif, status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
+  ptr_cutest_csgrshp_s_ = Libdl.dlsym(libsif, :cutest_csgrshp_s_)
   @ccall $ptr_cutest_csgrshp_s_(status::Ptr{Cint}, n::Ptr{Cint}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
                                 indvar::Ptr{Cint}, indfun::Ptr{Cint}, nnzh::Ptr{Cint},
                                 lh::Ptr{Cint}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csgreh_s_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, ne,
-                               le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_csgreh_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_csgreh_s_)
+function cutest_cint_csgreh_s_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar,
+                               indfun, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
+  ptr_cutest_cint_csgreh_s_ = Libdl.dlsym(libsif, :cutest_cint_csgreh_s_)
   @ccall $ptr_cutest_cint_csgreh_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float32},
                                     y::Ptr{Float32}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                     lcjac::Ptr{Cint}, cjac::Ptr{Float32}, indvar::Ptr{Cint},
@@ -1008,52 +981,53 @@ function cutest_cint_csgreh_s_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, in
                                     byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_chprod_s_(status, n, m, goth, x, y, p, q)
-  ptr_cutest_cint_chprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_chprod_s_)
+function cutest_cint_chprod_s_(libsif, status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chprod_s_ = Libdl.dlsym(libsif, :cutest_cint_chprod_s_)
   @ccall $ptr_cutest_cint_chprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float32}, y::Ptr{Float32}, p::Ptr{Float32},
                                     q::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_chsprod_s_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_chsprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_chsprod_s_)
+function cutest_cint_chsprod_s_(libsif, status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_chsprod_s_ = Libdl.dlsym(libsif, :cutest_cint_chsprod_s_)
   @ccall $ptr_cutest_cint_chsprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float32}, y::Ptr{Float32}, nnzp::Ptr{Cint},
                                      indp::Ptr{Cint}, p::Ptr{Float32}, nnzr::Ptr{Cint},
                                      indr::Ptr{Cint}, r::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_chcprod_s_(status, n, m, goth, x, y, p, q)
-  ptr_cutest_cint_chcprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_chcprod_s_)
+function cutest_cint_chcprod_s_(libsif, status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chcprod_s_ = Libdl.dlsym(libsif, :cutest_cint_chcprod_s_)
   @ccall $ptr_cutest_cint_chcprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float32}, y::Ptr{Float32}, p::Ptr{Float32},
                                      q::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_cshcprod_s_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_cshcprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cshcprod_s_)
+function cutest_cint_cshcprod_s_(libsif, status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_cshcprod_s_ = Libdl.dlsym(libsif, :cutest_cint_cshcprod_s_)
   @ccall $ptr_cutest_cint_cshcprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
                                       goth::Ptr{Bool}, x::Ptr{Float32}, y::Ptr{Float32},
                                       nnzp::Ptr{Cint}, indp::Ptr{Cint}, p::Ptr{Float32},
                                       nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_chjprod_s_(status, n, m, goth, x, y0, y, p, q)
-  ptr_cutest_cint_chjprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_chjprod_s_)
+function cutest_cint_chjprod_s_(libsif, status, n, m, goth, x, y0, y, p, q)
+  ptr_cutest_cint_chjprod_s_ = Libdl.dlsym(libsif, :cutest_cint_chjprod_s_)
   @ccall $ptr_cutest_cint_chjprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float32}, y0::Ptr{Float32}, y::Ptr{Float32},
                                      p::Ptr{Float32}, q::Ptr{Float32})::Cvoid
 end
 
-function cutest_cint_cjprod_s_(status, n, m, gotj, jtrans, x, p, lp, r, lr)
-  ptr_cutest_cint_cjprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cjprod_s_)
+function cutest_cint_cjprod_s_(libsif, status, n, m, gotj, jtrans, x, p, lp, r, lr)
+  ptr_cutest_cint_cjprod_s_ = Libdl.dlsym(libsif, :cutest_cint_cjprod_s_)
   @ccall $ptr_cutest_cint_cjprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
                                     jtrans::Ptr{Bool}, x::Ptr{Float32}, p::Ptr{Float32},
                                     lp::Ptr{Cint}, r::Ptr{Float32}, lr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csjprod_s_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr, indr, r, lr)
-  ptr_cutest_cint_csjprod_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_csjprod_s_)
+function cutest_cint_csjprod_s_(libsif, status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr,
+                                indr, r, lr)
+  ptr_cutest_cint_csjprod_s_ = Libdl.dlsym(libsif, :cutest_cint_csjprod_s_)
   @ccall $ptr_cutest_cint_csjprod_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
                                      jtrans::Ptr{Bool}, x::Ptr{Float32}, nnzp::Ptr{Cint},
                                      indp::Ptr{Cint}, p::Ptr{Float32}, lp::Ptr{Cint},
@@ -1061,64 +1035,64 @@ function cutest_cint_csjprod_s_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp
                                      lr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cchprods_s_(status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
-  ptr_cutest_cint_cchprods_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cchprods_s_)
+function cutest_cint_cchprods_s_(libsif, status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
+  ptr_cutest_cint_cchprods_s_ = Libdl.dlsym(libsif, :cutest_cint_cchprods_s_)
   @ccall $ptr_cutest_cint_cchprods_s_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
                                       goth::Ptr{Bool}, x::Ptr{Float32}, p::Ptr{Float32},
                                       lchp::Ptr{Cint}, chpval::Ptr{Float32}, chpind::Ptr{Cint},
                                       chpptr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cchprodsp_s_(status, m, lchp, chpind, chpptr)
-  ptr_cutest_cchprodsp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cchprodsp_s_)
+function cutest_cchprodsp_s_(libsif, status, m, lchp, chpind, chpptr)
+  ptr_cutest_cchprodsp_s_ = Libdl.dlsym(libsif, :cutest_cchprodsp_s_)
   @ccall $ptr_cutest_cchprodsp_s_(status::Ptr{Cint}, m::Ptr{Cint}, lchp::Ptr{Cint},
                                   chpind::Ptr{Cint}, chpptr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cohprods_s_(status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
-  ptr_cutest_cint_cohprods_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cint_cohprods_s_)
+function cutest_cint_cohprods_s_(libsif, status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
+  ptr_cutest_cint_cohprods_s_ = Libdl.dlsym(libsif, :cutest_cint_cohprods_s_)
   @ccall $ptr_cutest_cint_cohprods_s_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                       x::Ptr{Float32}, p::Ptr{Float32}, nnzohp::Ptr{Cint},
                                       lohp::Ptr{Cint}, ohpval::Ptr{Float32},
                                       ohpind::Ptr{Cint})::Cvoid
 end
 
-function cutest_cohprodsp_s_(status, nnzohp, lohp, chpind)
-  ptr_cutest_cohprodsp_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cohprodsp_s_)
+function cutest_cohprodsp_s_(libsif, status, nnzohp, lohp, chpind)
+  ptr_cutest_cohprodsp_s_ = Libdl.dlsym(libsif, :cutest_cohprodsp_s_)
   @ccall $ptr_cutest_cohprodsp_s_(status::Ptr{Cint}, nnzohp::Ptr{Cint}, lohp::Ptr{Cint},
                                   chpind::Ptr{Cint})::Cvoid
 end
 
-function cutest_uterminate_s_(status)
-  ptr_cutest_uterminate_s_ = Libdl.dlsym(cutest_lib_single, :cutest_uterminate_s_)
+function cutest_uterminate_s_(libsif, status)
+  ptr_cutest_uterminate_s_ = Libdl.dlsym(libsif, :cutest_uterminate_s_)
   @ccall $ptr_cutest_uterminate_s_(status::Ptr{Cint})::Cvoid
 end
 
-function cutest_cterminate_s_(status)
-  ptr_cutest_cterminate_s_ = Libdl.dlsym(cutest_lib_single, :cutest_cterminate_s_)
+function cutest_cterminate_s_(libsif, status)
+  ptr_cutest_cterminate_s_ = Libdl.dlsym(libsif, :cutest_cterminate_s_)
   @ccall $ptr_cutest_cterminate_s_(status::Ptr{Cint})::Cvoid
 end
 
-function fortran_open_s_(funit, fname, ierr)
-  ptr_fortran_open_s_ = Libdl.dlsym(cutest_lib_single, :fortran_open_s_)
+function fortran_open_s_(libsif, funit, fname, ierr)
+  ptr_fortran_open_s_ = Libdl.dlsym(libsif, :fortran_open_s_)
   @ccall $ptr_fortran_open_s_(funit::Ptr{Cint}, fname::Ptr{Cchar}, ierr::Ptr{Cint})::Cvoid
 end
 
-function fortran_close_s_(funit, ierr)
-  ptr_fortran_close_s_ = Libdl.dlsym(cutest_lib_single, :fortran_close_s_)
+function fortran_close_s_(libsif, funit, ierr)
+  ptr_fortran_close_s_ = Libdl.dlsym(libsif, :fortran_close_s_)
   @ccall $ptr_fortran_close_s_(funit::Ptr{Cint}, ierr::Ptr{Cint})::Cvoid
 end
 
-function cutest_usetup_q_(status, funit, iout, io_buffer, n, x, bl, bu)
-  ptr_cutest_usetup_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_usetup_q_)
+function cutest_usetup_q_(libsif, status, funit, iout, io_buffer, n, x, bl, bu)
+  ptr_cutest_usetup_q_ = Libdl.dlsym(libsif, :cutest_usetup_q_)
   @ccall $ptr_cutest_usetup_q_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                                io_buffer::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
                                bl::Ptr{Float128}, bu::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_csetup_q_(status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu, equatn,
-                               linear, e_order, l_order, v_order)
-  ptr_cutest_cint_csetup_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csetup_q_)
+function cutest_cint_csetup_q_(libsif, status, funit, iout, io_buffer, n, m, x, bl, bu, v, cl, cu,
+                               equatn, linear, e_order, l_order, v_order)
+  ptr_cutest_cint_csetup_q_ = Libdl.dlsym(libsif, :cutest_cint_csetup_q_)
   @ccall $ptr_cutest_cint_csetup_q_(status::Ptr{Cint}, funit::Ptr{Cint}, iout::Ptr{Cint},
                                     io_buffer::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
                                     x::Ptr{Float128}, bl::Ptr{Float128}, bu::Ptr{Float128},
@@ -1127,404 +1101,406 @@ function cutest_cint_csetup_q_(status, funit, iout, io_buffer, n, m, x, bl, bu, 
                                     l_order::Ptr{Cint}, v_order::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimen_q_(status, funit, n)
-  ptr_cutest_udimen_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udimen_q_)
+function cutest_udimen_q_(libsif, status, funit, n)
+  ptr_cutest_udimen_q_ = Libdl.dlsym(libsif, :cutest_udimen_q_)
   @ccall $ptr_cutest_udimen_q_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimsh_q_(status, nnzh)
-  ptr_cutest_udimsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udimsh_q_)
+function cutest_udimsh_q_(libsif, status, nnzh)
+  ptr_cutest_udimsh_q_ = Libdl.dlsym(libsif, :cutest_udimsh_q_)
   @ccall $ptr_cutest_udimsh_q_(status::Ptr{Cint}, nnzh::Ptr{Cint})::Cvoid
 end
 
-function cutest_udimse_q_(status, ne, nzh, nzirnh)
-  ptr_cutest_udimse_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udimse_q_)
+function cutest_udimse_q_(libsif, status, ne, nzh, nzirnh)
+  ptr_cutest_udimse_q_ = Libdl.dlsym(libsif, :cutest_udimse_q_)
   @ccall $ptr_cutest_udimse_q_(status::Ptr{Cint}, ne::Ptr{Cint}, nzh::Ptr{Cint},
                                nzirnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_uvartype_q_(status, n, ivarty)
-  ptr_cutest_uvartype_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_uvartype_q_)
+function cutest_uvartype_q_(libsif, status, n, ivarty)
+  ptr_cutest_uvartype_q_ = Libdl.dlsym(libsif, :cutest_uvartype_q_)
   @ccall $ptr_cutest_uvartype_q_(status::Ptr{Cint}, n::Ptr{Cint}, ivarty::Ptr{Cint})::Cvoid
 end
 
-function cutest_unames_q_(status, n, pname, vnames)
-  ptr_cutest_unames_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_unames_q_)
+function cutest_unames_q_(libsif, status, n, pname, vnames)
+  ptr_cutest_unames_q_ = Libdl.dlsym(libsif, :cutest_unames_q_)
   @ccall $ptr_cutest_unames_q_(status::Ptr{Cint}, n::Ptr{Cint}, pname::Ptr{Cchar},
                                vnames::Ptr{Cchar})::Cvoid
 end
 
-function cutest_ureport_q_(status, calls, time)
-  ptr_cutest_ureport_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ureport_q_)
+function cutest_ureport_q_(libsif, status, calls, time)
+  ptr_cutest_ureport_q_ = Libdl.dlsym(libsif, :cutest_ureport_q_)
   @ccall $ptr_cutest_ureport_q_(status::Ptr{Cint}, calls::Ptr{Float128}, time::Ptr{Float128})::Cvoid
 end
 
-function cutest_cdimen_q_(status, funit, n, m)
-  ptr_cutest_cdimen_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimen_q_)
+function cutest_cdimen_q_(libsif, status, funit, n, m)
+  ptr_cutest_cdimen_q_ = Libdl.dlsym(libsif, :cutest_cdimen_q_)
   @ccall $ptr_cutest_cdimen_q_(status::Ptr{Cint}, funit::Ptr{Cint}, n::Ptr{Cint},
                                m::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cnoobj_q_(status, funit, noobj)
-  ptr_cutest_cint_cnoobj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cnoobj_q_)
+function cutest_cint_cnoobj_q_(libsif, status, funit, noobj)
+  ptr_cutest_cint_cnoobj_q_ = Libdl.dlsym(libsif, :cutest_cint_cnoobj_q_)
   @ccall $ptr_cutest_cint_cnoobj_q_(status::Ptr{Cint}, funit::Ptr{Cint}, noobj::Ptr{Bool})::Cvoid
 end
 
-function cutest_cdimsg_q_(status, nnzg)
-  ptr_cutest_cdimsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimsg_q_)
+function cutest_cdimsg_q_(libsif, status, nnzg)
+  ptr_cutest_cdimsg_q_ = Libdl.dlsym(libsif, :cutest_cdimsg_q_)
   @ccall $ptr_cutest_cdimsg_q_(status::Ptr{Cint}, nnzg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimsj_q_(status, nnzj)
-  ptr_cutest_cdimsj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimsj_q_)
+function cutest_cdimsj_q_(libsif, status, nnzj)
+  ptr_cutest_cdimsj_q_ = Libdl.dlsym(libsif, :cutest_cdimsj_q_)
   @ccall $ptr_cutest_cdimsj_q_(status::Ptr{Cint}, nnzj::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimsh_q_(status, nnzh)
-  ptr_cutest_cdimsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimsh_q_)
+function cutest_cdimsh_q_(libsif, status, nnzh)
+  ptr_cutest_cdimsh_q_ = Libdl.dlsym(libsif, :cutest_cdimsh_q_)
   @ccall $ptr_cutest_cdimsh_q_(status::Ptr{Cint}, nnzh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimohp_q_(status, nnzohp)
-  ptr_cutest_cdimohp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimohp_q_)
+function cutest_cdimohp_q_(libsif, status, nnzohp)
+  ptr_cutest_cdimohp_q_ = Libdl.dlsym(libsif, :cutest_cdimohp_q_)
   @ccall $ptr_cutest_cdimohp_q_(status::Ptr{Cint}, nnzohp::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimchp_q_(status, nnzchp)
-  ptr_cutest_cdimchp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimchp_q_)
+function cutest_cdimchp_q_(libsif, status, nnzchp)
+  ptr_cutest_cdimchp_q_ = Libdl.dlsym(libsif, :cutest_cdimchp_q_)
   @ccall $ptr_cutest_cdimchp_q_(status::Ptr{Cint}, nnzchp::Ptr{Cint})::Cvoid
 end
 
-function cutest_cdimse_q_(status, ne, nzh, nzirnh)
-  ptr_cutest_cdimse_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdimse_q_)
+function cutest_cdimse_q_(libsif, status, ne, nzh, nzirnh)
+  ptr_cutest_cdimse_q_ = Libdl.dlsym(libsif, :cutest_cdimse_q_)
   @ccall $ptr_cutest_cdimse_q_(status::Ptr{Cint}, ne::Ptr{Cint}, nzh::Ptr{Cint},
                                nzirnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cstats_q_(status, nonlinear_variables_objective, nonlinear_variables_constraints,
-                          equality_constraints, linear_constraints)
-  ptr_cutest_cstats_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cstats_q_)
+function cutest_cstats_q_(libsif, status, nonlinear_variables_objective,
+                          nonlinear_variables_constraints, equality_constraints, linear_constraints)
+  ptr_cutest_cstats_q_ = Libdl.dlsym(libsif, :cutest_cstats_q_)
   @ccall $ptr_cutest_cstats_q_(status::Ptr{Cint}, nonlinear_variables_objective::Ptr{Cint},
                                nonlinear_variables_constraints::Ptr{Cint},
                                equality_constraints::Ptr{Cint},
                                linear_constraints::Ptr{Cint})::Cvoid
 end
 
-function cutest_cvartype_q_(status, n, ivarty)
-  ptr_cutest_cvartype_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cvartype_q_)
+function cutest_cvartype_q_(libsif, status, n, ivarty)
+  ptr_cutest_cvartype_q_ = Libdl.dlsym(libsif, :cutest_cvartype_q_)
   @ccall $ptr_cutest_cvartype_q_(status::Ptr{Cint}, n::Ptr{Cint}, ivarty::Ptr{Cint})::Cvoid
 end
 
-function cutest_cnames_q_(status, n, m, pname, vnames, gnames)
-  ptr_cutest_cnames_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cnames_q_)
+function cutest_cnames_q_(libsif, status, n, m, pname, vnames, gnames)
+  ptr_cutest_cnames_q_ = Libdl.dlsym(libsif, :cutest_cnames_q_)
   @ccall $ptr_cutest_cnames_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, pname::Ptr{Cchar},
                                vnames::Ptr{Cchar}, gnames::Ptr{Cchar})::Cvoid
 end
 
-function cutest_creport_q_(status, calls, time)
-  ptr_cutest_creport_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_creport_q_)
+function cutest_creport_q_(libsif, status, calls, time)
+  ptr_cutest_creport_q_ = Libdl.dlsym(libsif, :cutest_creport_q_)
   @ccall $ptr_cutest_creport_q_(status::Ptr{Cint}, calls::Ptr{Float128}, time::Ptr{Float128})::Cvoid
 end
 
-function cutest_connames_q_(status, m, gname)
-  ptr_cutest_connames_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_connames_q_)
+function cutest_connames_q_(libsif, status, m, gname)
+  ptr_cutest_connames_q_ = Libdl.dlsym(libsif, :cutest_connames_q_)
   @ccall $ptr_cutest_connames_q_(status::Ptr{Cint}, m::Ptr{Cint}, gname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_pname_q_(status, funit, pname)
-  ptr_cutest_pname_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_pname_q_)
+function cutest_pname_q_(libsif, status, funit, pname)
+  ptr_cutest_pname_q_ = Libdl.dlsym(libsif, :cutest_pname_q_)
   @ccall $ptr_cutest_pname_q_(status::Ptr{Cint}, funit::Ptr{Cint}, pname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_probname_q_(status, pname)
-  ptr_cutest_probname_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_probname_q_)
+function cutest_probname_q_(libsif, status, pname)
+  ptr_cutest_probname_q_ = Libdl.dlsym(libsif, :cutest_probname_q_)
   @ccall $ptr_cutest_probname_q_(status::Ptr{Cint}, pname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_varnames_q_(status, n, vname)
-  ptr_cutest_varnames_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_varnames_q_)
+function cutest_varnames_q_(libsif, status, n, vname)
+  ptr_cutest_varnames_q_ = Libdl.dlsym(libsif, :cutest_varnames_q_)
   @ccall $ptr_cutest_varnames_q_(status::Ptr{Cint}, n::Ptr{Cint}, vname::Ptr{Cchar})::Cvoid
 end
 
-function cutest_ufn_q_(status, n, x, f)
-  ptr_cutest_ufn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ufn_q_)
+function cutest_ufn_q_(libsif, status, n, x, f)
+  ptr_cutest_ufn_q_ = Libdl.dlsym(libsif, :cutest_ufn_q_)
   @ccall $ptr_cutest_ufn_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
                             f::Ptr{Float128})::Cvoid
 end
 
-function cutest_ugr_q_(status, n, x, g)
-  ptr_cutest_ugr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugr_q_)
+function cutest_ugr_q_(libsif, status, n, x, g)
+  ptr_cutest_ugr_q_ = Libdl.dlsym(libsif, :cutest_ugr_q_)
   @ccall $ptr_cutest_ugr_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
                             g::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_uofg_q_(status, n, x, f, g, grad)
-  ptr_cutest_cint_uofg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_uofg_q_)
+function cutest_cint_uofg_q_(libsif, status, n, x, f, g, grad)
+  ptr_cutest_cint_uofg_q_ = Libdl.dlsym(libsif, :cutest_cint_uofg_q_)
   @ccall $ptr_cutest_cint_uofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, f::Ptr{Float128},
                                   g::Ptr{Float128}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_udh_q_(status, n, x, lh1, h)
-  ptr_cutest_udh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_udh_q_)
+function cutest_udh_q_(libsif, status, n, x, lh1, h)
+  ptr_cutest_udh_q_ = Libdl.dlsym(libsif, :cutest_udh_q_)
   @ccall $ptr_cutest_udh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, lh1::Ptr{Cint},
                             h::Ptr{Float128})::Cvoid
 end
 
-function cutest_ushp_q_(status, n, nnzh, lh, irnh, icnh)
-  ptr_cutest_ushp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ushp_q_)
+function cutest_ushp_q_(libsif, status, n, nnzh, lh, irnh, icnh)
+  ptr_cutest_ushp_q_ = Libdl.dlsym(libsif, :cutest_ushp_q_)
   @ccall $ptr_cutest_ushp_q_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_ush_q_(status, n, x, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_ush_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ush_q_)
+function cutest_ush_q_(libsif, status, n, x, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ush_q_ = Libdl.dlsym(libsif, :cutest_ush_q_)
   @ccall $ptr_cutest_ush_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, nnzh::Ptr{Cint},
                             lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ueh_q_(status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_ueh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ueh_q_)
+function cutest_cint_ueh_q_(libsif, status, n, x, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
+                            byrows)
+  ptr_cutest_cint_ueh_q_ = Libdl.dlsym(libsif, :cutest_cint_ueh_q_)
   @ccall $ptr_cutest_cint_ueh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, ne::Ptr{Cint},
                                  le::Ptr{Cint}, iprnhi::Ptr{Cint}, iprhi::Ptr{Cint},
                                  lirnhi::Ptr{Cint}, irnhi::Ptr{Cint}, lhi::Ptr{Cint},
                                  hi::Ptr{Float128}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_ugrdh_q_(status, n, x, g, lh1, h)
-  ptr_cutest_ugrdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugrdh_q_)
+function cutest_ugrdh_q_(libsif, status, n, x, g, lh1, h)
+  ptr_cutest_ugrdh_q_ = Libdl.dlsym(libsif, :cutest_ugrdh_q_)
   @ccall $ptr_cutest_ugrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, g::Ptr{Float128},
                               lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
-function cutest_ugrsh_q_(status, n, x, g, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_ugrsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ugrsh_q_)
+function cutest_ugrsh_q_(libsif, status, n, x, g, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_ugrsh_q_ = Libdl.dlsym(libsif, :cutest_ugrsh_q_)
   @ccall $ptr_cutest_ugrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, g::Ptr{Float128},
                               nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint},
                               icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ugreh_q_(status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
-                              byrows)
-  ptr_cutest_cint_ugreh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ugreh_q_)
+function cutest_cint_ugreh_q_(libsif, status, n, x, g, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi,
+                              hi, byrows)
+  ptr_cutest_cint_ugreh_q_ = Libdl.dlsym(libsif, :cutest_cint_ugreh_q_)
   @ccall $ptr_cutest_cint_ugreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
                                    g::Ptr{Float128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                    iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
                                    lhi::Ptr{Cint}, hi::Ptr{Float128}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_uhprod_q_(status, n, goth, x, p, r)
-  ptr_cutest_cint_uhprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_uhprod_q_)
+function cutest_cint_uhprod_q_(libsif, status, n, goth, x, p, r)
+  ptr_cutest_cint_uhprod_q_ = Libdl.dlsym(libsif, :cutest_cint_uhprod_q_)
   @ccall $ptr_cutest_cint_uhprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float128}, p::Ptr{Float128}, r::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_ushprod_q_(status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_ushprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ushprod_q_)
+function cutest_cint_ushprod_q_(libsif, status, n, goth, x, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_ushprod_q_ = Libdl.dlsym(libsif, :cutest_cint_ushprod_q_)
   @ccall $ptr_cutest_cint_ushprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float128}, nnzp::Ptr{Cint}, indp::Ptr{Cint},
                                      p::Ptr{Float128}, nnzr::Ptr{Cint}, indr::Ptr{Cint},
                                      r::Ptr{Float128})::Cvoid
 end
 
-function cutest_ubandh_q_(status, n, x, nsemib, bandh, lbandh, maxsbw)
-  ptr_cutest_ubandh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_ubandh_q_)
+function cutest_ubandh_q_(libsif, status, n, x, nsemib, bandh, lbandh, maxsbw)
+  ptr_cutest_ubandh_q_ = Libdl.dlsym(libsif, :cutest_ubandh_q_)
   @ccall $ptr_cutest_ubandh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, nsemib::Ptr{Cint},
                                bandh::Ptr{Float128}, lbandh::Ptr{Cint}, maxsbw::Ptr{Cint})::Cvoid
 end
 
-function cutest_cfn_q_(status, n, m, x, f, c)
-  ptr_cutest_cfn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cfn_q_)
+function cutest_cfn_q_(libsif, status, n, m, x, f, c)
+  ptr_cutest_cfn_q_ = Libdl.dlsym(libsif, :cutest_cfn_q_)
   @ccall $ptr_cutest_cfn_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                             f::Ptr{Float128}, c::Ptr{Float128})::Cvoid
 end
 
-function cutest_cconst_q_(status, m, c)
-  ptr_cutest_cconst_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cconst_q_)
+function cutest_cconst_q_(libsif, status, m, c)
+  ptr_cutest_cconst_q_ = Libdl.dlsym(libsif, :cutest_cconst_q_)
   @ccall $ptr_cutest_cconst_q_(status::Ptr{Cint}, m::Ptr{Cint}, c::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_cofg_q_(status, n, x, f, g, grad)
-  ptr_cutest_cint_cofg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cofg_q_)
+function cutest_cint_cofg_q_(libsif, status, n, x, f, g, grad)
+  ptr_cutest_cint_cofg_q_ = Libdl.dlsym(libsif, :cutest_cint_cofg_q_)
   @ccall $ptr_cutest_cint_cofg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, f::Ptr{Float128},
                                   g::Ptr{Float128}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cofsg_q_(status, n, x, f, nnzg, lg, sg, ivsg, grad)
-  ptr_cutest_cint_cofsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cofsg_q_)
+function cutest_cint_cofsg_q_(libsif, status, n, x, f, nnzg, lg, sg, ivsg, grad)
+  ptr_cutest_cint_cofsg_q_ = Libdl.dlsym(libsif, :cutest_cint_cofsg_q_)
   @ccall $ptr_cutest_cint_cofsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128},
                                    f::Ptr{Float128}, nnzg::Ptr{Cint}, lg::Ptr{Cint},
                                    sg::Ptr{Float128}, ivsg::Ptr{Cint}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccfg_q_(status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
-  ptr_cutest_cint_ccfg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccfg_q_)
+function cutest_cint_ccfg_q_(libsif, status, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+  ptr_cutest_cint_ccfg_q_ = Libdl.dlsym(libsif, :cutest_cint_ccfg_q_)
   @ccall $ptr_cutest_cint_ccfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                   c::Ptr{Float128}, jtrans::Ptr{Bool}, lcjac1::Ptr{Cint},
                                   lcjac2::Ptr{Cint}, cjac::Ptr{Float128}, grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_clfg_q_(status, n, m, x, y, f, g, grad)
-  ptr_cutest_cint_clfg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_clfg_q_)
+function cutest_cint_clfg_q_(libsif, status, n, m, x, y, f, g, grad)
+  ptr_cutest_cint_clfg_q_ = Libdl.dlsym(libsif, :cutest_cint_clfg_q_)
   @ccall $ptr_cutest_cint_clfg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                   y::Ptr{Float128}, f::Ptr{Float128}, g::Ptr{Float128},
                                   grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cgr_q_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
-  ptr_cutest_cint_cgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cgr_q_)
+function cutest_cint_cgr_q_(libsif, status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac)
+  ptr_cutest_cint_cgr_q_ = Libdl.dlsym(libsif, :cutest_cint_cgr_q_)
   @ccall $ptr_cutest_cint_cgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                  y::Ptr{Float128}, grlagf::Ptr{Bool}, g::Ptr{Float128},
                                  jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
                                  cjac::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_csgr_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
-  ptr_cutest_cint_csgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgr_q_)
+function cutest_cint_csgr_q_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun)
+  ptr_cutest_cint_csgr_q_ = Libdl.dlsym(libsif, :cutest_cint_csgr_q_)
   @ccall $ptr_cutest_cint_csgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                   y::Ptr{Float128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                   lcjac::Ptr{Cint}, cjac::Ptr{Float128}, indvar::Ptr{Cint},
                                   indfun::Ptr{Cint})::Cvoid
 end
 
-function cutest_csgrp_q_(status, n, nnzj, lj, jvar, jcon)
-  ptr_cutest_csgrp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_csgrp_q_)
+function cutest_csgrp_q_(libsif, status, n, nnzj, lj, jvar, jcon)
+  ptr_cutest_csgrp_q_ = Libdl.dlsym(libsif, :cutest_csgrp_q_)
   @ccall $ptr_cutest_csgrp_q_(status::Ptr{Cint}, n::Ptr{Cint}, nnzj::Ptr{Cint}, lj::Ptr{Cint},
                               jvar::Ptr{Cint}, jcon::Ptr{Cint})::Cvoid
 end
 
-function cutest_csjp_q_(status, nnzj, lj, jvar, jcon)
-  ptr_cutest_csjp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_csjp_q_)
+function cutest_csjp_q_(libsif, status, nnzj, lj, jvar, jcon)
+  ptr_cutest_csjp_q_ = Libdl.dlsym(libsif, :cutest_csjp_q_)
   @ccall $ptr_cutest_csjp_q_(status::Ptr{Cint}, nnzj::Ptr{Cint}, lj::Ptr{Cint}, jvar::Ptr{Cint},
                              jcon::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ccfsg_q_(status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
-  ptr_cutest_cint_ccfsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccfsg_q_)
+function cutest_cint_ccfsg_q_(libsif, status, n, m, x, c, nnzj, lcjac, cjac, indvar, indfun, grad)
+  ptr_cutest_cint_ccfsg_q_ = Libdl.dlsym(libsif, :cutest_cint_ccfsg_q_)
   @ccall $ptr_cutest_cint_ccfsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                    c::Ptr{Float128}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
                                    cjac::Ptr{Float128}, indvar::Ptr{Cint}, indfun::Ptr{Cint},
                                    grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccifg_q_(status, n, icon, x, ci, gci, grad)
-  ptr_cutest_cint_ccifg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccifg_q_)
+function cutest_cint_ccifg_q_(libsif, status, n, icon, x, ci, gci, grad)
+  ptr_cutest_cint_ccifg_q_ = Libdl.dlsym(libsif, :cutest_cint_ccifg_q_)
   @ccall $ptr_cutest_cint_ccifg_q_(status::Ptr{Cint}, n::Ptr{Cint}, icon::Ptr{Cint},
                                    x::Ptr{Float128}, ci::Ptr{Float128}, gci::Ptr{Float128},
                                    grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_ccifsg_q_(status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
-  ptr_cutest_cint_ccifsg_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ccifsg_q_)
+function cutest_cint_ccifsg_q_(libsif, status, n, con, x, ci, nnzsgc, lsgci, sgci, ivsgci, grad)
+  ptr_cutest_cint_ccifsg_q_ = Libdl.dlsym(libsif, :cutest_cint_ccifsg_q_)
   @ccall $ptr_cutest_cint_ccifsg_q_(status::Ptr{Cint}, n::Ptr{Cint}, con::Ptr{Cint},
                                     x::Ptr{Float128}, ci::Ptr{Float128}, nnzsgc::Ptr{Cint},
                                     lsgci::Ptr{Cint}, sgci::Ptr{Float128}, ivsgci::Ptr{Cint},
                                     grad::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_cgrdh_q_(status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac, lh1, h)
-  ptr_cutest_cint_cgrdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cgrdh_q_)
+function cutest_cint_cgrdh_q_(libsif, status, n, m, x, y, grlagf, g, jtrans, lcjac1, lcjac2, cjac,
+                              lh1, h)
+  ptr_cutest_cint_cgrdh_q_ = Libdl.dlsym(libsif, :cutest_cint_cgrdh_q_)
   @ccall $ptr_cutest_cint_cgrdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                    y::Ptr{Float128}, grlagf::Ptr{Bool}, g::Ptr{Float128},
                                    jtrans::Ptr{Bool}, lcjac1::Ptr{Cint}, lcjac2::Ptr{Cint},
                                    cjac::Ptr{Float128}, lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
-function cutest_cdh_q_(status, n, m, x, y, lh1, h)
-  ptr_cutest_cdh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdh_q_)
+function cutest_cdh_q_(libsif, status, n, m, x, y, lh1, h)
+  ptr_cutest_cdh_q_ = Libdl.dlsym(libsif, :cutest_cdh_q_)
   @ccall $ptr_cutest_cdh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                             y::Ptr{Float128}, lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
-function cutest_cdhc_q_(status, n, m, x, y, lh1, h)
-  ptr_cutest_cdhc_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdhc_q_)
+function cutest_cdhc_q_(libsif, status, n, m, x, y, lh1, h)
+  ptr_cutest_cdhc_q_ = Libdl.dlsym(libsif, :cutest_cdhc_q_)
   @ccall $ptr_cutest_cdhc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                              y::Ptr{Float128}, lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
-function cutest_cdhj_q_(status, n, m, x, y0, y, lh1, h)
-  ptr_cutest_cdhj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cdhj_q_)
+function cutest_cdhj_q_(libsif, status, n, m, x, y0, y, lh1, h)
+  ptr_cutest_cdhj_q_ = Libdl.dlsym(libsif, :cutest_cdhj_q_)
   @ccall $ptr_cutest_cdhj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                              y0::Ptr{Float128}, y::Ptr{Float128}, lh1::Ptr{Cint},
                              h::Ptr{Float128})::Cvoid
 end
 
-function cutest_cshp_q_(status, n, nnzh, lh, irnh, icnh)
-  ptr_cutest_cshp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshp_q_)
+function cutest_cshp_q_(libsif, status, n, nnzh, lh, irnh, icnh)
+  ptr_cutest_cshp_q_ = Libdl.dlsym(libsif, :cutest_cshp_q_)
   @ccall $ptr_cutest_cshp_q_(status::Ptr{Cint}, n::Ptr{Cint}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_csh_q_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_csh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_csh_q_)
+function cutest_csh_q_(libsif, status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_csh_q_ = Libdl.dlsym(libsif, :cutest_csh_q_)
   @ccall $ptr_cutest_csh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                             y::Ptr{Float128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128},
                             irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cshc_q_(status, n, m, x, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cshc_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshc_q_)
+function cutest_cshc_q_(libsif, status, n, m, x, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshc_q_ = Libdl.dlsym(libsif, :cutest_cshc_q_)
   @ccall $ptr_cutest_cshc_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                              y::Ptr{Float128}, nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128},
                              irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cshj_q_(status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cshj_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cshj_q_)
+function cutest_cshj_q_(libsif, status, n, m, x, y0, y, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cshj_q_ = Libdl.dlsym(libsif, :cutest_cshj_q_)
   @ccall $ptr_cutest_cshj_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                              y0::Ptr{Float128}, y::Ptr{Float128}, nnzh::Ptr{Cint}, lh::Ptr{Cint},
                              h::Ptr{Float128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_ceh_q_(status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi,
-                            byrows)
-  ptr_cutest_cint_ceh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_ceh_q_)
+function cutest_cint_ceh_q_(libsif, status, n, m, x, y, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi,
+                            hi, byrows)
+  ptr_cutest_cint_ceh_q_ = Libdl.dlsym(libsif, :cutest_cint_ceh_q_)
   @ccall $ptr_cutest_cint_ceh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                  y::Ptr{Float128}, ne::Ptr{Cint}, le::Ptr{Cint}, iprnhi::Ptr{Cint},
                                  iprhi::Ptr{Cint}, lirnhi::Ptr{Cint}, irnhi::Ptr{Cint},
                                  lhi::Ptr{Cint}, hi::Ptr{Float128}, byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cifn_q_(status, n, iprob, x, f)
-  ptr_cutest_cifn_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cifn_q_)
+function cutest_cifn_q_(libsif, status, n, iprob, x, f)
+  ptr_cutest_cifn_q_ = Libdl.dlsym(libsif, :cutest_cifn_q_)
   @ccall $ptr_cutest_cifn_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float128},
                              f::Ptr{Float128})::Cvoid
 end
 
-function cutest_cigr_q_(status, n, iprob, x, g)
-  ptr_cutest_cigr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cigr_q_)
+function cutest_cigr_q_(libsif, status, n, iprob, x, g)
+  ptr_cutest_cigr_q_ = Libdl.dlsym(libsif, :cutest_cigr_q_)
   @ccall $ptr_cutest_cigr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float128},
                              g::Ptr{Float128})::Cvoid
 end
 
-function cutest_cisgr_q_(status, n, iprob, x, nnzg, lg, sg, ivsg)
-  ptr_cutest_cisgr_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cisgr_q_)
+function cutest_cisgr_q_(libsif, status, n, iprob, x, nnzg, lg, sg, ivsg)
+  ptr_cutest_cisgr_q_ = Libdl.dlsym(libsif, :cutest_cisgr_q_)
   @ccall $ptr_cutest_cisgr_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, x::Ptr{Float128},
                               nnzg::Ptr{Cint}, lg::Ptr{Cint}, sg::Ptr{Float128},
                               ivsg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cisgrp_q_(status, n, iprob, nnzg, lg, ivsg)
-  ptr_cutest_cisgrp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cisgrp_q_)
+function cutest_cisgrp_q_(libsif, status, n, iprob, nnzg, lg, ivsg)
+  ptr_cutest_cisgrp_q_ = Libdl.dlsym(libsif, :cutest_cisgrp_q_)
   @ccall $ptr_cutest_cisgrp_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzg::Ptr{Cint},
                                lg::Ptr{Cint}, ivsg::Ptr{Cint})::Cvoid
 end
 
-function cutest_cidh_q_(status, n, x, iprob, lh1, h)
-  ptr_cutest_cidh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cidh_q_)
+function cutest_cidh_q_(libsif, status, n, x, iprob, lh1, h)
+  ptr_cutest_cidh_q_ = Libdl.dlsym(libsif, :cutest_cidh_q_)
   @ccall $ptr_cutest_cidh_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, iprob::Ptr{Cint},
                              lh1::Ptr{Cint}, h::Ptr{Float128})::Cvoid
 end
 
-function cutest_cish_q_(status, n, x, iprob, nnzh, lh, h, irnh, icnh)
-  ptr_cutest_cish_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cish_q_)
+function cutest_cish_q_(libsif, status, n, x, iprob, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cish_q_ = Libdl.dlsym(libsif, :cutest_cish_q_)
   @ccall $ptr_cutest_cish_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, iprob::Ptr{Cint},
                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint},
                              icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csgrsh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, nnzh,
-                               lh, h, irnh, icnh)
-  ptr_cutest_cint_csgrsh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgrsh_q_)
+function cutest_cint_csgrsh_q_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar,
+                               indfun, nnzh, lh, h, irnh, icnh)
+  ptr_cutest_cint_csgrsh_q_ = Libdl.dlsym(libsif, :cutest_cint_csgrsh_q_)
   @ccall $ptr_cutest_cint_csgrsh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                     y::Ptr{Float128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                     lcjac::Ptr{Cint}, cjac::Ptr{Float128}, indvar::Ptr{Cint},
@@ -1532,16 +1508,16 @@ function cutest_cint_csgrsh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, in
                                     h::Ptr{Float128}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_csgrshp_q_(status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
-  ptr_cutest_csgrshp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_csgrshp_q_)
+function cutest_csgrshp_q_(libsif, status, n, nnzj, lcjac, indvar, indfun, nnzh, lh, irnh, icnh)
+  ptr_cutest_csgrshp_q_ = Libdl.dlsym(libsif, :cutest_csgrshp_q_)
   @ccall $ptr_cutest_csgrshp_q_(status::Ptr{Cint}, n::Ptr{Cint}, nnzj::Ptr{Cint}, lcjac::Ptr{Cint},
                                 indvar::Ptr{Cint}, indfun::Ptr{Cint}, nnzh::Ptr{Cint},
                                 lh::Ptr{Cint}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csgreh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun, ne,
-                               le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
-  ptr_cutest_cint_csgreh_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csgreh_q_)
+function cutest_cint_csgreh_q_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar,
+                               indfun, ne, le, iprnhi, iprhi, lirnhi, irnhi, lhi, hi, byrows)
+  ptr_cutest_cint_csgreh_q_ = Libdl.dlsym(libsif, :cutest_cint_csgreh_q_)
   @ccall $ptr_cutest_cint_csgreh_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, x::Ptr{Float128},
                                     y::Ptr{Float128}, grlagf::Ptr{Bool}, nnzj::Ptr{Cint},
                                     lcjac::Ptr{Cint}, cjac::Ptr{Float128}, indvar::Ptr{Cint},
@@ -1551,52 +1527,53 @@ function cutest_cint_csgreh_q_(status, n, m, x, y, grlagf, nnzj, lcjac, cjac, in
                                     byrows::Ptr{Bool})::Cvoid
 end
 
-function cutest_cint_chprod_q_(status, n, m, goth, x, y, p, q)
-  ptr_cutest_cint_chprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chprod_q_)
+function cutest_cint_chprod_q_(libsif, status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chprod_q_ = Libdl.dlsym(libsif, :cutest_cint_chprod_q_)
   @ccall $ptr_cutest_cint_chprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                     x::Ptr{Float128}, y::Ptr{Float128}, p::Ptr{Float128},
                                     q::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_chsprod_q_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_chsprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chsprod_q_)
+function cutest_cint_chsprod_q_(libsif, status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_chsprod_q_ = Libdl.dlsym(libsif, :cutest_cint_chsprod_q_)
   @ccall $ptr_cutest_cint_chsprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float128}, y::Ptr{Float128}, nnzp::Ptr{Cint},
                                      indp::Ptr{Cint}, p::Ptr{Float128}, nnzr::Ptr{Cint},
                                      indr::Ptr{Cint}, r::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_chcprod_q_(status, n, m, goth, x, y, p, q)
-  ptr_cutest_cint_chcprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chcprod_q_)
+function cutest_cint_chcprod_q_(libsif, status, n, m, goth, x, y, p, q)
+  ptr_cutest_cint_chcprod_q_ = Libdl.dlsym(libsif, :cutest_cint_chcprod_q_)
   @ccall $ptr_cutest_cint_chcprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float128}, y::Ptr{Float128}, p::Ptr{Float128},
                                      q::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_cshcprod_q_(status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
-  ptr_cutest_cint_cshcprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cshcprod_q_)
+function cutest_cint_cshcprod_q_(libsif, status, n, m, goth, x, y, nnzp, indp, p, nnzr, indr, r)
+  ptr_cutest_cint_cshcprod_q_ = Libdl.dlsym(libsif, :cutest_cint_cshcprod_q_)
   @ccall $ptr_cutest_cint_cshcprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
                                       goth::Ptr{Bool}, x::Ptr{Float128}, y::Ptr{Float128},
                                       nnzp::Ptr{Cint}, indp::Ptr{Cint}, p::Ptr{Float128},
                                       nnzr::Ptr{Cint}, indr::Ptr{Cint}, r::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_chjprod_q_(status, n, m, goth, x, y0, y, p, q)
-  ptr_cutest_cint_chjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_chjprod_q_)
+function cutest_cint_chjprod_q_(libsif, status, n, m, goth, x, y0, y, p, q)
+  ptr_cutest_cint_chjprod_q_ = Libdl.dlsym(libsif, :cutest_cint_chjprod_q_)
   @ccall $ptr_cutest_cint_chjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, goth::Ptr{Bool},
                                      x::Ptr{Float128}, y0::Ptr{Float128}, y::Ptr{Float128},
                                      p::Ptr{Float128}, q::Ptr{Float128})::Cvoid
 end
 
-function cutest_cint_cjprod_q_(status, n, m, gotj, jtrans, x, p, lp, r, lr)
-  ptr_cutest_cint_cjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cjprod_q_)
+function cutest_cint_cjprod_q_(libsif, status, n, m, gotj, jtrans, x, p, lp, r, lr)
+  ptr_cutest_cint_cjprod_q_ = Libdl.dlsym(libsif, :cutest_cint_cjprod_q_)
   @ccall $ptr_cutest_cint_cjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
                                     jtrans::Ptr{Bool}, x::Ptr{Float128}, p::Ptr{Float128},
                                     lp::Ptr{Cint}, r::Ptr{Float128}, lr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_csjprod_q_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr, indr, r, lr)
-  ptr_cutest_cint_csjprod_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_csjprod_q_)
+function cutest_cint_csjprod_q_(libsif, status, n, m, gotj, jtrans, x, nnzp, indp, p, lp, nnzr,
+                                indr, r, lr)
+  ptr_cutest_cint_csjprod_q_ = Libdl.dlsym(libsif, :cutest_cint_csjprod_q_)
   @ccall $ptr_cutest_cint_csjprod_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint}, gotj::Ptr{Bool},
                                      jtrans::Ptr{Bool}, x::Ptr{Float128}, nnzp::Ptr{Cint},
                                      indp::Ptr{Cint}, p::Ptr{Float128}, lp::Ptr{Cint},
@@ -1604,51 +1581,51 @@ function cutest_cint_csjprod_q_(status, n, m, gotj, jtrans, x, nnzp, indp, p, lp
                                      lr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cchprods_q_(status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
-  ptr_cutest_cint_cchprods_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cchprods_q_)
+function cutest_cint_cchprods_q_(libsif, status, n, m, goth, x, p, lchp, chpval, chpind, chpptr)
+  ptr_cutest_cint_cchprods_q_ = Libdl.dlsym(libsif, :cutest_cint_cchprods_q_)
   @ccall $ptr_cutest_cint_cchprods_q_(status::Ptr{Cint}, n::Ptr{Cint}, m::Ptr{Cint},
                                       goth::Ptr{Bool}, x::Ptr{Float128}, p::Ptr{Float128},
                                       lchp::Ptr{Cint}, chpval::Ptr{Float128}, chpind::Ptr{Cint},
                                       chpptr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cchprodsp_q_(status, m, lchp, chpind, chpptr)
-  ptr_cutest_cchprodsp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cchprodsp_q_)
+function cutest_cchprodsp_q_(libsif, status, m, lchp, chpind, chpptr)
+  ptr_cutest_cchprodsp_q_ = Libdl.dlsym(libsif, :cutest_cchprodsp_q_)
   @ccall $ptr_cutest_cchprodsp_q_(status::Ptr{Cint}, m::Ptr{Cint}, lchp::Ptr{Cint},
                                   chpind::Ptr{Cint}, chpptr::Ptr{Cint})::Cvoid
 end
 
-function cutest_cint_cohprods_q_(status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
-  ptr_cutest_cint_cohprods_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cint_cohprods_q_)
+function cutest_cint_cohprods_q_(libsif, status, n, goth, x, p, nnzohp, lohp, ohpval, ohpind)
+  ptr_cutest_cint_cohprods_q_ = Libdl.dlsym(libsif, :cutest_cint_cohprods_q_)
   @ccall $ptr_cutest_cint_cohprods_q_(status::Ptr{Cint}, n::Ptr{Cint}, goth::Ptr{Bool},
                                       x::Ptr{Float128}, p::Ptr{Float128}, nnzohp::Ptr{Cint},
                                       lohp::Ptr{Cint}, ohpval::Ptr{Float128},
                                       ohpind::Ptr{Cint})::Cvoid
 end
 
-function cutest_cohprodsp_q_(status, nnzohp, lohp, chpind)
-  ptr_cutest_cohprodsp_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cohprodsp_q_)
+function cutest_cohprodsp_q_(libsif, status, nnzohp, lohp, chpind)
+  ptr_cutest_cohprodsp_q_ = Libdl.dlsym(libsif, :cutest_cohprodsp_q_)
   @ccall $ptr_cutest_cohprodsp_q_(status::Ptr{Cint}, nnzohp::Ptr{Cint}, lohp::Ptr{Cint},
                                   chpind::Ptr{Cint})::Cvoid
 end
 
-function cutest_uterminate_q_(status)
-  ptr_cutest_uterminate_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_uterminate_q_)
+function cutest_uterminate_q_(libsif, status)
+  ptr_cutest_uterminate_q_ = Libdl.dlsym(libsif, :cutest_uterminate_q_)
   @ccall $ptr_cutest_uterminate_q_(status::Ptr{Cint})::Cvoid
 end
 
-function cutest_cterminate_q_(status)
-  ptr_cutest_cterminate_q_ = Libdl.dlsym(cutest_lib_quadruple, :cutest_cterminate_q_)
+function cutest_cterminate_q_(libsif, status)
+  ptr_cutest_cterminate_q_ = Libdl.dlsym(libsif, :cutest_cterminate_q_)
   @ccall $ptr_cutest_cterminate_q_(status::Ptr{Cint})::Cvoid
 end
 
-function fortran_open_q_(funit, fname, ierr)
-  ptr_fortran_open_q_ = Libdl.dlsym(cutest_lib_quadruple, :fortran_open_q_)
+function fortran_open_q_(libsif, funit, fname, ierr)
+  ptr_fortran_open_q_ = Libdl.dlsym(libsif, :fortran_open_q_)
   @ccall $ptr_fortran_open_q_(funit::Ptr{Cint}, fname::Ptr{Cchar}, ierr::Ptr{Cint})::Cvoid
 end
 
-function fortran_close_q_(funit, ierr)
-  ptr_fortran_close_q_ = Libdl.dlsym(cutest_lib_quadruple, :fortran_close_q_)
+function fortran_close_q_(libsif, funit, ierr)
+  ptr_fortran_close_q_ = Libdl.dlsym(libsif, :fortran_close_q_)
   @ccall $ptr_fortran_close_q_(funit::Ptr{Cint}, ierr::Ptr{Cint})::Cvoid
 end
 #! format: on

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -144,7 +144,7 @@ function build_libsif(
       end
       if Sys.isapple()
         libcutest = joinpath(libpath, "lib$library.a")
-        run(`gfortran -dynamiclib -o $(libsif_name).$dlext $(object_files) -Wl,--all_load $libcutest`)
+        run(`gfortran -dynamiclib -o $(libsif_name).$dlext $(object_files) -Wl,-all_load $libcutest`)
       elseif Sys.iswindows()
         @static if Sys.iswindows()
           mingw = Int == Int64 ? "mingw64" : "mingw32"

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -143,8 +143,8 @@ function build_libsif(
         end
       end
       if Sys.isapple()
-        libcutest = joinpath(libpath, "lib$library.$dlext")
-        run(`gfortran -dynamiclib -o $(libsif_name).$dlext $(object_files) -Wl,-rpath,$libpath $libcutest`)
+        libcutest = joinpath(libpath, "lib$library.a")
+        run(`gfortran -dynamiclib -o $(libsif_name).$dlext $(object_files) -Wl,--all_load $libcutest`)
       elseif Sys.iswindows()
         @static if Sys.iswindows()
           mingw = Int == Int64 ? "mingw64" : "mingw32"
@@ -155,9 +155,9 @@ function build_libsif(
           )
         end
       else
-        libgfortran = strip(read(`gfortran --print-file libgfortran.so`, String))
+        libcutest = joinpath(libpath, "lib$library.a")
         run(
-          `ld -shared -o $(libsif_name).$dlext $(object_files) -rpath=$libpath -L$libpath -l$library $libgfortran`,
+          `gfortran -shared -o $(libsif_name).$dlext $(object_files) -Wl,--whole-archive $libcutest -Wl,--no-whole-archive`,
         )
       end
       delete_temp_files(suffix)

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -3,35 +3,35 @@ function coverage_increase(nlp::CUTEstModel{T}) where {T}
   status = Cint[0]
   n, m = nlp.meta.nvar, nlp.meta.ncon
   pname = Vector{Cchar}(undef, 10)
-  CUTEst.probname(T, status, pname)
+  CUTEst.probname(T, nlp.libsif, status, pname)
   vname = Matrix{Cchar}(undef, 10, n)
-  CUTEst.varnames(T, status, Cint[n], vname)
+  CUTEst.varnames(T, nlp.libsif, status, Cint[n], vname)
   if m == 0
-    CUTEst.unames(T, status, Cint[n], pname, vname)
+    CUTEst.unames(T, nlp.libsif, status, Cint[n], pname, vname)
     calls = Vector{T}(undef, 4)
     time = Vector{T}(undef, 4)
-    CUTEst.ureport(T, status, calls, time)
+    CUTEst.ureport(T, nlp.libsif, status, calls, time)
   else
     cname = Matrix{Cchar}(undef, 10, m)
-    CUTEst.connames(T, status, Cint[m], cname)
-    CUTEst.cnames(T, status, Cint[n], Cint[m], pname, vname, cname)
+    CUTEst.connames(T, nlp.libsif, status, Cint[m], cname)
+    CUTEst.cnames(T, nlp.libsif, status, Cint[n], Cint[m], pname, vname, cname)
     calls = Vector{T}(undef, 7)
     time = Vector{T}(undef, 4)
-    CUTEst.creport(T, status, calls, time)
+    CUTEst.creport(T, nlp.libsif, status, calls, time)
     nvo, nvc, ec, lc = Cint[0], Cint[0], Cint[0], Cint[0]
-    CUTEst.cstats(T, status, nvo, nvc, ec, lc)
+    CUTEst.cstats(T, nlp.libsif, status, nvo, nvc, ec, lc)
 
     lchp = Cint[0]
-    CUTEst.cdimchp(T, status, lchp)
+    CUTEst.cdimchp(T, nlp.libsif, status, lchp)
     chp_ind, chp_ptr = Vector{Cint}(undef, lchp[1]), Vector{Cint}(undef, m + 1)
-    CUTEst.cchprodsp(T, status, Cint[m], lchp, chp_ind, chp_ptr)
+    CUTEst.cchprodsp(T, nlp.libsif, status, Cint[m], lchp, chp_ind, chp_ptr)
     lj, nnzj = Cint[0], Cint[0]
-    CUTEst.cdimsj(T, status, lj)
+    CUTEst.cdimsj(T, nlp.libsif, status, lj)
     j_var, j_fun = Vector{Cint}(undef, lj[1]), Vector{Cint}(undef, lj[1])
-    CUTEst.csgrp(T, status, Cint[n], nnzj, lj, j_var, j_fun)
+    CUTEst.csgrp(T, nlp.libsif, status, Cint[n], nnzj, lj, j_var, j_fun)
     lh, nnzh = Cint[0], Cint[0]
-    CUTEst.cdimsh(T, status, lh)
+    CUTEst.cdimsh(T, nlp.libsif, status, lh)
     h_row, h_col = Vector{Cint}(undef, lh[1]), Vector{Cint}(undef, lh[1])
-    CUTEst.csgrshp(T, status, Cint[n], nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)
+    CUTEst.csgrshp(T, nlp.libsif, status, Cint[n], nnzj, lj, j_var, j_fun, nnzh, lh, h_row, h_col)
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,9 @@ for p in problems
     fval = T[0.0]
     if ncon > 0
       cx = zeros(T, ncon)
-      CUTEst.cfn(T, status, Cint[nvar], Cint[ncon], x0, fval, cx)
+      CUTEst.cfn(T, nlp.libsif, status, Cint[nvar], Cint[ncon], x0, fval, cx)
     else
-      CUTEst.ufn(T, status, Cint[nvar], x0, fval)
+      CUTEst.ufn(T, nlp.libsif, status, Cint[nvar], x0, fval)
     end
     println("$p: core interface: f(x₀) = $(fval[1])")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,15 @@ for pb in problems
   println()
 end
 
+for T in (Float32, Float64, Float128)
+  @testset "Multiple instances of CUTEstModel -- $T" begin
+    nlps = [CUTEstModel{T}(problem) for problem in problems]
+    for nlp in nlps
+      finalize(nlp)
+    end
+  end
+end
+
 include("test_core.jl")
 include("test_julia.jl")
 include("coverage.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,11 +21,13 @@ for pb in problems
   println()
 end
 
-for T in (Float32, Float64, Float128)
-  @testset "Multiple instances of CUTEstModel -- $T" begin
-    nlps = [CUTEstModel{T}(problem) for problem in problems]
-    for nlp in nlps
-      finalize(nlp)
+if Sys.iswindows() || VERSION ≥ v"1.10"
+  for T in (Float32, Float64, Float128)
+    @testset "Multiple instances of CUTEstModel -- $T" begin
+      nlps = [CUTEstModel{T}(problem) for problem in problems]
+      for nlp in nlps
+        finalize(nlp)
+      end
     end
   end
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -82,24 +82,24 @@ function test_coreinterface(
 
   @testset "Core interface" begin
     if (ncon[1] > 0)
-      CUTEst.cfn(T, st, nvar, ncon, x0, fx, cx)
+      CUTEst.cfn(T, nlp.libsif, st, nvar, ncon, x0, fx, cx)
       @test isapprox(fx[1], f(x0), rtol = rtol)
       compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
 
-      CUTEst.cifn(T, st, nvar, Cint[0], x0, fx)
+      CUTEst.cifn(T, nlp.libsif, st, nvar, Cint[0], x0, fx)
       @test isapprox(fx[1], f(x0), rtol = rtol)
       for i = 1:ncon[1]
-        CUTEst.cifn(T, st, nvar, Cint[i], x0, cx)
+        CUTEst.cifn(T, nlp.libsif, st, nvar, Cint[i], x0, cx)
         #@test isapprox(cx[1], c(x0)[i], rtol = rtol)
         @test isapprox(cx[1] - nlp.meta.ucon[i], c(x0)[i] - comp_nlp.meta.ucon[i], rtol = rtol)
         @test isapprox(cx[1] - nlp.meta.lcon[i], c(x0)[i] - comp_nlp.meta.lcon[i], rtol = rtol)
       end
 
-      CUTEst.cofg(T, st, nvar, x0, fx, gx, True)
+      CUTEst.cofg(T, nlp.libsif, st, nvar, x0, fx, gx, True)
       @test isapprox(fx[1], f(x0), rtol = rtol)
       @test isapprox(gx, g(x0), rtol = rtol)
 
-      CUTEst.cofsg(T, st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
+      CUTEst.cofsg(T, nlp.libsif, st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
       @test isapprox(fx[1], f(x0), rtol = rtol)
       gx = zeros(T, nvar[1])
       for i = 1:nnzg[1]
@@ -107,44 +107,44 @@ function test_coreinterface(
       end
       @test isapprox(gx, g(x0), rtol = rtol)
 
-      CUTEst.ccfg(T, st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
+      CUTEst.ccfg(T, nlp.libsif, st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
       @test isapprox(Jtx, J(x0)', rtol = rtol)
-      CUTEst.ccfg(T, st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
+      CUTEst.ccfg(T, nlp.libsif, st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
-      CUTEst.clfg(T, st, nvar, ncon, x0, y0, lx, glx, True)
+      CUTEst.clfg(T, nlp.libsif, st, nvar, ncon, x0, y0, lx, glx, True)
       @test isapprox(lx[1], f(x0) + dot(y0, cx), rtol = rtol)
       @test isapprox(glx, g(x0) + J(x0)' * y0, rtol = rtol)
 
-      CUTEst.cgr(T, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
+      CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
       @test isapprox(gx, g(x0), rtol = rtol)
       @test isapprox(Jtx, J(x0)', rtol = rtol)
-      CUTEst.cgr(T, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
+      CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
       @test isapprox(gx, g(x0), rtol = rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
-      CUTEst.cgr(T, st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
+      CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
       @test isapprox(glx, g(x0) + J(x0)' * y0, rtol = rtol)
       @test isapprox(Jtx, J(x0)', rtol = rtol)
-      CUTEst.cgr(T, st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
+      CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
       @test isapprox(glx, g(x0) + J(x0)' * y0, rtol = rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
-      CUTEst.cigr(T, st, nvar, Cint[0], x0, gval)
+      CUTEst.cigr(T, nlp.libsif, st, nvar, Cint[0], x0, gval)
       @test isapprox(gval, g(x0), rtol = rtol)
       for i = 1:ncon[1]
-        CUTEst.cigr(T, st, nvar, Cint[i], x0, gval)
+        CUTEst.cigr(T, nlp.libsif, st, nvar, Cint[i], x0, gval)
         @test isapprox(gval, J(x0)[i, :], rtol = rtol)
       end
 
-      CUTEst.cisgr(T, st, nvar, Cint[0], x0, nnzg, nvar, gval, gvar)
+      CUTEst.cisgr(T, nlp.libsif, st, nvar, Cint[0], x0, nnzg, nvar, gval, gvar)
       I = 1:nnzg[1]
       @test isapprox(gval[I], g(x0)[gvar[I]], rtol = rtol)
       for i = 1:ncon[1]
-        CUTEst.cisgr(T, st, nvar, Cint[i], x0, nnzg, nvar, gval, gvar)
+        CUTEst.cisgr(T, nlp.libsif, st, nvar, Cint[i], x0, nnzg, nvar, gval, gvar)
         @test isapprox(gval, J(x0)[i, gvar[1:nnzg[1]]], rtol = rtol)
       end
 
-      CUTEst.csgr(T, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
+      CUTEst.csgr(T, nlp.libsif, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
       glx = zeros(T, nvar[1])
       Jx = zeros(T, nvar[1], ncon[1])
       for k = 1:nnzj[1]
@@ -156,7 +156,7 @@ function test_coreinterface(
       end
       @test isapprox(glx, g(x0) + J(x0)' * y0, rtol = rtol)
       @test isapprox(Jtx, J(x0)', rtol = rtol)
-      CUTEst.csgr(T, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
+      CUTEst.csgr(T, nlp.libsif, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
       gx = zeros(T, nvar[1])
       Jx = zeros(T, ncon[1], nvar[1])
       for k = 1:nnzj[1]
@@ -169,7 +169,7 @@ function test_coreinterface(
       @test isapprox(gx, g(x0), rtol = rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
-      CUTEst.ccfsg(T, st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
+      CUTEst.ccfsg(T, nlp.libsif, st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
       Jx = zeros(T, ncon[1], nvar[1])
       for k = 1:nnzj[1]
         Jx[Jfun[k], Jvar[k]] = Jval[k]
@@ -178,7 +178,7 @@ function test_coreinterface(
       @test isapprox(Jx, J(x0), rtol = rtol)
 
       for j = 1:ncon[1]
-        CUTEst.ccifg(T, st, nvar, Cint[j], x0, ci, gci, True)
+        CUTEst.ccifg(T, nlp.libsif, st, nvar, Cint[j], x0, ci, gci, True)
         cx[j] = ci[1]
         Jx[j, :] = gci'
       end
@@ -187,7 +187,7 @@ function test_coreinterface(
 
       Jx = zeros(T, ncon[1], nvar[1])
       for j = 1:ncon[1]
-        CUTEst.ccifsg(T, st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
+        CUTEst.ccifsg(T, nlp.libsif, st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
         cx[j] = ci[1]
         for k = 1:nnzj[1]
           Jx[j, Jvar[k]] = Jval[k]
@@ -196,27 +196,27 @@ function test_coreinterface(
       compare_cons(nlp, cx, comp_nlp, c(x0), rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
 
-      CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar, Wx)
+      CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar, Wx)
       @test isapprox(gx, g(x0), rtol = rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
-      CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar, Wx)
+      CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar, Wx)
       @test isapprox(gx, g(x0), rtol = rtol)
       @test isapprox(Jtx, J(x0)', rtol = rtol)
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
-      CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar, Wx)
+      CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar, Wx)
       @test isapprox(gx, g(x0) + J(x0)' * y0, rtol = rtol)
       @test isapprox(Jx, J(x0), rtol = rtol)
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
-      CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar, Wx)
+      CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar, Wx)
       @test isapprox(gx, g(x0) + J(x0)' * y0, rtol = rtol)
       @test isapprox(Jtx, J(x0)', rtol = rtol)
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
 
-      CUTEst.cdh(T, st, nvar, ncon, x0, y0, nvar, Wx)
+      CUTEst.cdh(T, nlp.libsif, st, nvar, ncon, x0, y0, nvar, Wx)
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
 
-      CUTEst.csh(T, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+      CUTEst.csh(T, nlp.libsif, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
       Wx = zeros(T, nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]
@@ -226,7 +226,7 @@ function test_coreinterface(
       end
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
 
-      CUTEst.cshc(T, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+      CUTEst.cshc(T, nlp.libsif, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
       Cx = zeros(T, nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]
@@ -236,17 +236,17 @@ function test_coreinterface(
       end
       @test isapprox(Cx, (W(x0, y0) - H(x0)), rtol = rtol)
 
-      CUTEst.cidh(T, st, nvar, x0, Cint[0], nvar, Hx)
+      CUTEst.cidh(T, nlp.libsif, st, nvar, x0, Cint[0], nvar, Hx)
       @test isapprox(Hx, H(x0), rtol = rtol)
       y1 = zeros(T, ncon[1])
       for k = 1:ncon[1]
-        CUTEst.cidh(T, st, nvar, x0, Cint[k], nvar, Cx)
+        CUTEst.cidh(T, nlp.libsif, st, nvar, x0, Cint[k], nvar, Cx)
         y1[k] = one(T)
         @test isapprox(Cx, (W(x0, y1) - H(x0)), rtol = rtol)
         y1[k] = zero(T)
       end
 
-      CUTEst.cish(T, st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
+      CUTEst.cish(T, nlp.libsif, st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
       Hx = zeros(T, nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]
@@ -257,7 +257,7 @@ function test_coreinterface(
       @test isapprox(Hx, H(x0), rtol = rtol)
       y1 = zeros(T, ncon[1])
       for k = 1:ncon[1]
-        CUTEst.cish(T, st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
+        CUTEst.cish(T, nlp.libsif, st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
         Cx = zeros(T, nvar[1], nvar[1])
         for k2 = 1:nnzh[1]
           i = Hrow[k2]
@@ -272,6 +272,7 @@ function test_coreinterface(
 
       CUTEst.csgrsh(
         T,
+        nlp.libsif,
         st,
         nvar,
         ncon,
@@ -310,6 +311,7 @@ function test_coreinterface(
       @test isapprox(Wx, W(x0, y0), rtol = rtol)
       CUTEst.csgrsh(
         T,
+        nlp.libsif,
         st,
         nvar,
         ncon,
@@ -349,32 +351,32 @@ function test_coreinterface(
 
       v = ones(T, nvar[1])
       Hv = Vector{T}(undef, nvar[1])
-      CUTEst.chprod(T, st, nvar, ncon, False, x0, y0, v, Hv)
+      CUTEst.chprod(T, nlp.libsif, st, nvar, ncon, False, x0, y0, v, Hv)
       @test isapprox(Hv, W(x0, y0) * v, rtol = rtol)
 
       Hv = Vector{T}(undef, nvar[1])
-      CUTEst.chcprod(T, st, nvar, ncon, False, x0, y0, v, Hv)
+      CUTEst.chcprod(T, nlp.libsif, st, nvar, ncon, False, x0, y0, v, Hv)
       @test isapprox(Hv, (W(x0, y0) - H(x0)) * v, rtol = rtol)
 
       v = ones(T, nvar[1])
       Jv = Vector{T}(undef, ncon[1])
-      CUTEst.cjprod(T, st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
+      CUTEst.cjprod(T, nlp.libsif, st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
       @test isapprox(Jv, J(x0) * v, rtol = rtol)
       v = ones(T, ncon[1])
       Jtv = Vector{T}(undef, nvar[1])
-      CUTEst.cjprod(T, st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
+      CUTEst.cjprod(T, nlp.libsif, st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
       @test isapprox(Jtv, J(x0)' * v, rtol = rtol)
     else
-      CUTEst.ufn(T, st, nvar, x0, fx)
+      CUTEst.ufn(T, nlp.libsif, st, nvar, x0, fx)
       @test isapprox(fx[1], f(x0), rtol = rtol)
 
-      CUTEst.ugr(T, st, nvar, x0, gx)
+      CUTEst.ugr(T, nlp.libsif, st, nvar, x0, gx)
       @test isapprox(gx, g(x0), rtol = rtol)
 
-      CUTEst.udh(T, st, nvar, x0, nvar, Hx)
+      CUTEst.udh(T, nlp.libsif, st, nvar, x0, nvar, Hx)
       @test isapprox(Hx, H(x0), rtol = rtol)
 
-      CUTEst.ush(T, st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
+      CUTEst.ush(T, nlp.libsif, st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
       Hx = zeros(T, nvar[1], nvar[1])
       for k = 1:nnzh[1]
         i = Hrow[k]
@@ -384,11 +386,11 @@ function test_coreinterface(
       end
       @test isapprox(Hx, H(x0), rtol = rtol)
 
-      CUTEst.ugrdh(T, st, nvar, x0, gx, nvar, Hx)
+      CUTEst.ugrdh(T, nlp.libsif, st, nvar, x0, gx, nvar, Hx)
       @test isapprox(gx, g(x0), rtol = rtol)
       @test isapprox(Hx, H(x0), rtol = rtol)
 
-      CUTEst.ugrsh(T, st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
+      CUTEst.ugrsh(T, nlp.libsif, st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
       @test isapprox(gx, g(x0), rtol = rtol)
       Hx = zeros(T, nvar[1], nvar[1])
       for k = 1:nnzh[1]
@@ -401,10 +403,10 @@ function test_coreinterface(
 
       v = ones(T, nvar[1])
       Hv = Vector{T}(undef, nvar[1])
-      CUTEst.uhprod(T, st, nvar, False, x0, v, Hv)
+      CUTEst.uhprod(T, nlp.libsif, st, nvar, False, x0, v, Hv)
       @test isapprox(Hv, H(x0) * v, rtol = rtol)
 
-      CUTEst.uofg(T, st, nvar, x0, fx, gx, True)
+      CUTEst.uofg(T, nlp.libsif, st, nvar, x0, fx, gx, True)
       @test isapprox(fx[1], f(x0), rtol = rtol)
       @test isapprox(gx, g(x0), rtol = rtol)
     end
@@ -412,42 +414,43 @@ function test_coreinterface(
     print("Core interface stress test... ")
     for i = 1:10000
       if (ncon[1] > 0)
-        CUTEst.cfn(T, st, nvar, ncon, x0, fx, cx)
-        CUTEst.cofg(T, st, nvar, x0, fx, gx, True)
-        CUTEst.cofsg(T, st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
-        CUTEst.ccfg(T, st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
-        CUTEst.ccfg(T, st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
-        CUTEst.clfg(T, st, nvar, ncon, x0, y0, lx, glx, True)
-        CUTEst.cgr(T, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
-        CUTEst.cgr(T, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
-        CUTEst.cgr(T, st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
-        CUTEst.cgr(T, st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
-        CUTEst.csgr(T, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
-        CUTEst.csgr(T, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
-        CUTEst.ccfsg(T, st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
+        CUTEst.cfn(T, nlp.libsif, st, nvar, ncon, x0, fx, cx)
+        CUTEst.cofg(T, nlp.libsif, st, nvar, x0, fx, gx, True)
+        CUTEst.cofsg(T, nlp.libsif, st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
+        CUTEst.ccfg(T, nlp.libsif, st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
+        CUTEst.ccfg(T, nlp.libsif, st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
+        CUTEst.clfg(T, nlp.libsif, st, nvar, ncon, x0, y0, lx, glx, True)
+        CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
+        CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
+        CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
+        CUTEst.cgr(T, nlp.libsif, st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
+        CUTEst.csgr(T, nlp.libsif, st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
+        CUTEst.csgr(T, nlp.libsif, st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
+        CUTEst.ccfsg(T, nlp.libsif, st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
         for j = 1:ncon[1]
-          CUTEst.ccifg(T, st, nvar, Cint[j], x0, ci, gci, True)
+          CUTEst.ccifg(T, nlp.libsif, st, nvar, Cint[j], x0, ci, gci, True)
         end
         for j = 1:ncon[1]
-          CUTEst.ccifsg(T, st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
+          CUTEst.ccifsg(T, nlp.libsif, st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
         end
-        CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar, Wx)
-        CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar, Wx)
-        CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar, Wx)
-        CUTEst.cgrdh(T, st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar, Wx)
-        CUTEst.cdh(T, st, nvar, ncon, x0, y0, nvar, Wx)
-        CUTEst.csh(T, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
-        CUTEst.cshc(T, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
-        CUTEst.cidh(T, st, nvar, x0, Cint[0], nvar, Hx)
+        CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar, Wx)
+        CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar, Wx)
+        CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar, Wx)
+        CUTEst.cgrdh(T, nlp.libsif, st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar, Wx)
+        CUTEst.cdh(T, nlp.libsif, st, nvar, ncon, x0, y0, nvar, Wx)
+        CUTEst.csh(T, nlp.libsif, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+        CUTEst.cshc(T, nlp.libsif, st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+        CUTEst.cidh(T, nlp.libsif, st, nvar, x0, Cint[0], nvar, Hx)
         for k = 1:ncon[1]
-          CUTEst.cidh(T, st, nvar, x0, Cint[k], nvar, Cx)
+          CUTEst.cidh(T, nlp.libsif, st, nvar, x0, Cint[k], nvar, Cx)
         end
-        CUTEst.cish(T, st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
+        CUTEst.cish(T, nlp.libsif, st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
         for k = 1:ncon[1]
-          CUTEst.cish(T, st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
+          CUTEst.cish(T, nlp.libsif, st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
         end
         CUTEst.csgrsh(
           T,
+          nlp.libsif,
           st,
           nvar,
           ncon,
@@ -467,6 +470,7 @@ function test_coreinterface(
         )
         CUTEst.csgrsh(
           T,
+          nlp.libsif,
           st,
           nvar,
           ncon,
@@ -484,19 +488,19 @@ function test_coreinterface(
           Hrow,
           Hcol,
         )
-        CUTEst.chprod(T, st, nvar, ncon, False, x0, y0, v, Hv)
-        CUTEst.chcprod(T, st, nvar, ncon, False, x0, y0, v, Hv)
-        CUTEst.cjprod(T, st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
-        CUTEst.cjprod(T, st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
+        CUTEst.chprod(T, nlp.libsif, st, nvar, ncon, False, x0, y0, v, Hv)
+        CUTEst.chcprod(T, nlp.libsif, st, nvar, ncon, False, x0, y0, v, Hv)
+        CUTEst.cjprod(T, nlp.libsif, st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
+        CUTEst.cjprod(T, nlp.libsif, st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
       else
-        CUTEst.ufn(T, st, nvar, x0, fx)
-        CUTEst.ugr(T, st, nvar, x0, gx)
-        CUTEst.udh(T, st, nvar, x0, nvar, Hx)
-        CUTEst.ush(T, st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
-        CUTEst.ugrdh(T, st, nvar, x0, gx, nvar, Hx)
-        CUTEst.ugrsh(T, st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
-        CUTEst.uhprod(T, st, nvar, False, x0, v, Hv)
-        CUTEst.uofg(T, st, nvar, x0, fx, gx, True)
+        CUTEst.ufn(T, nlp.libsif, st, nvar, x0, fx)
+        CUTEst.ugr(T, nlp.libsif, st, nvar, x0, gx)
+        CUTEst.udh(T, nlp.libsif, st, nvar, x0, nvar, Hx)
+        CUTEst.ush(T, nlp.libsif, st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
+        CUTEst.ugrdh(T, nlp.libsif, st, nvar, x0, gx, nvar, Hx)
+        CUTEst.ugrsh(T, nlp.libsif, st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
+        CUTEst.uhprod(T, nlp.libsif, st, nvar, False, x0, v, Hv)
+        CUTEst.uofg(T, nlp.libsif, st, nvar, x0, fx, gx, True)
       end
     end
     println("passed")


### PR DESCRIPTION
Each shared library dedicated to a SIF problem in a given precision is no longer linked to the same `libcutest_$precision.$dlext`. This previously caused issues when attempting to use multiple `CUTEstModel` instances for the same precision simultaneously. 

By using static libraries instead, multiple problems can now be used simultaneously without conflict, as each library is independent from the others due to static linking.

I have modified the wrapper generator to add a `libsif` argument, which is of type `Ptr{Cvoid}`, returned by `Libdl.dlopen`. Each `CUTEstModel` now has a `libsif` field.

Users no longer need to manually call `finalizer(nlp)`; the garbage collector will handle it automatically. The only scenario where it might be necessary is if the user recreates a model with the same problem:

```julia
nlp1 = CUTEstModel{Float64}("HS1")
finalize(nlp1)
nlp2 = CUTEstModel{Float64}("HS1")
```
It could be relevant in the case that the dimension of the problem is modified.

I have removed all global variables related to paths and the number of instantiated problems for a given precision.

I also updated the `README.md` to remove the `@everywhere` trick, as it is no longer necessary.

Note that we can't do this on macOS/Linux with Julia 1.6 because the Fortran compilers used to cross-compile binaries / Julia are incompatible with the `libgfortran` provided by the user's compiler.
Fortunately, Julia 1.10 will soon become the new LTS version.
  
cc @tmigot 