### PR TITLE
Add an option to compile standalone shared libraries for SIF problems

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -130,11 +130,11 @@ function CUTEstModel{T}(
   status = Ref{Cint}(0)
 
   cd(libsif_path) do
-    libsif_name = "lib$(pname)_$(precision)"
+    libsif_name = _name_libsif(pname, precision)
     if !decode
-      isfile(outsdif) || error("CUTEst: no decoded problem found")
-      isfile("$libsif_name.$dlext") ||
-        error("CUTEst: $libsif_name.$dlext not found; decode problem first")
+      isfile(outsdif) || error("CUTEst: $outsdif not found; decode the problem $pname first")
+      isfile(libsif_name) ||
+        error("CUTEst: $libsif_name not found; decode the problem $pname first")
     else
       sifdecoder(path_sifname, args...; verbose, precision)
       build_libsif(path_sifname; precision)

--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -212,6 +212,7 @@ function build_libsif(
           push!(object_files, "$fname.o")
         end
       end
+      #! format: off
       if Sys.isapple()
         if standalone
           run(`gfortran -dynamiclib -o $libsif_name $object_files`)
@@ -235,6 +236,7 @@ function build_libsif(
           run(`gfortran -shared -o $libsif_name $object_files -Wl,--whole-archive $libcutest -Wl,--no-whole-archive`)
         end
       end
+      #! format: on
       delete_temp_files(pname, suffix)
     else
       error("The file $pname.SIF was not decoded in the folder $libsif_folder.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,19 @@ for pb in problems
   for precision in (:single, :double, :quadruple)
     (precision == :quadruple) && (Sys.ARCH == :aarch64) && Sys.islinux() && continue
     print("$precision ")
-    build_libsif(pb, precision = precision, standalone=true)
-    build_libsif(pb, precision = precision, standalone=false)
+    build_libsif(pb, precision = precision)
+    println("✓")
+  end
+  println()
+end
+
+for pb in problems
+    println("--- build_libsif -- $pb --- standalone")
+  for precision in (:single, :double, :quadruple)
+    (precision == :quadruple) && (Sys.ARCH == :aarch64) && Sys.islinux() && continue
+    print("$precision ")
+    sifdecoder(pb, precision = precision)
+    build_libsif(pb, precision = precision, standalone = true)
     println("✓")
   end
   println()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ for pb in problems
   for precision in (:single, :double, :quadruple)
     (precision == :quadruple) && (Sys.ARCH == :aarch64) && Sys.islinux() && continue
     print("$precision ")
-    build_libsif(pb, precision = precision)
+    build_libsif(pb, precision = precision, standalone=true)
+    build_libsif(pb, precision = precision, standalone=false)
     println("✓")
   end
   println()


### PR DESCRIPTION
close #446 

Feature relevant for `GALAHAD.jl` where we don't want `libcutest.a` embedded in the shared library of the SIF problem.