### PR TITLE
nlp doc change

### DIFF
--- a/docs/src/core.md
+++ b/docs/src/core.md
@@ -21,11 +21,12 @@ using CUTEst, Quadmath
 
 # Float32, Float64 and Float128 are supported
 T = Float64
-nlp = CUTEstModel{T}("PROBLEM")
-x = rand(T, nlp.meta.nvar)
-f = Ref{T}()
-CUTEst.ufn(T, nlp.libsif, nlp.status, nlp.nvar, x, f)
-println(f[])
+CUTEstModel{T}("PROBLEM") do nlp
+    x = rand(T, nlp.meta.nvar)
+    f = Ref{T}()
+    CUTEst.ufn(T, nlp.libsif, nlp.status, nlp.nvar, x, f)
+    println(f[])
+end
 ```
 
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -67,9 +67,10 @@ You can pass parameters to `sifdecoder` by providing additional arguments to `CU
 using CUTEst
 
 for nh in 50:50:200
-  nlp = CUTEstModel{Float64}("CHAIN", "-param", "NH=$nh")
-  println("nh = $nh, nnzh = $(nlp.meta.nnzh)")
-  finalize(nlp)
+  CUTEstModel{Float64}("CHAIN", "-param", "NH=$nh") do nlp
+    println("nh = $nh, nnzh = $(nlp.meta.nnzh)")
+    finalize(nlp)
+  end
 end
 ```
 


### PR DESCRIPTION
Removed outdated call to `finalize(nlp)` and recommended using the `CUTEstModel("PROBLEM") do nlp ... end` syntax for automatic cleanup as mentioned #275, thus this Closes #442.

- Also want to add that we don't need a tutorial.md when the contents of the file is an introduction video and it is already mentioned on the readme.md file.