### PR TITLE
Update core_interface.jl

### DIFF
--- a/docs/src/core.md
+++ b/docs/src/core.md
@@ -93,6 +93,9 @@ CUTEst.cchprodsp
 CUTEst.cconst
 CUTEst.udimen
 CUTEst.pname
+CUTEst.chjprod
+CUTEst.cohprods
+CUTEst.chsprod
 CUTEst.chprod
 CUTEst.cterminate
 CUTEst.cifn


### PR DESCRIPTION
This PR adds chsprod, chjprod, and cohprods routines to the CUTEst core_interface.jl as C-compatible function wrappers.
Adds interface bindings for:
- cutest_chsprod
- cutest_chjprod
- cutest_cohprods

Closes #347