### PR TITLE
Update CUTEst.jl for SIFDecode 3.1.0

### DIFF
--- a/src/sifdecoder.jl
+++ b/src/sifdecoder.jl
@@ -139,7 +139,7 @@ function sifdecoder(
       ),
     )
     error_str = read(errlog, String)
-    if length(error_str) > 0
+    if length(error_str) > 0 && (error_str != "STOP 0\n")
       println(error_str)
       error("Unable to compile a shared library for the problem $name.")
     end


### PR DESCRIPTION
@jfowkes @nimgould
The new release of SIFDecode broke `CUTEst.jl` because `STOP 0` is written in `stderr` and not `stdout`.
I was checking that `stderr` was empty before.
This PR quickly fixes the issue.

It could be relevant for you to know that if you want to use it in the Python interface.