### PR TITLE
Interface cishp

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ SIFDecode_jll = "54dcf436-342f-53ea-8005-3708a1ae6c8c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUTEst_jll = "2.5.6"
+CUTEst_jll = "2.6.0"
 Combinatorics = "1.0"
 DataStructures = "0.18"
 JSON = "0.21"

--- a/docs/src/core.md
+++ b/docs/src/core.md
@@ -33,6 +33,7 @@ CUTEst.cjprod
 CUTEst.ccfg
 CUTEst.ccf
 CUTEst.cish
+CUTEst.cishp
 CUTEst.ushprod
 CUTEst.cdimchp
 CUTEst.ureport

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -4,5 +4,5 @@ Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 
 [compat]
-CUTEst_jll = "2.5.0"
+CUTEst_jll = "2.6.0"
 julia = "1.10"

--- a/gen/wrapper.jl
+++ b/gen/wrapper.jl
@@ -31,6 +31,12 @@ function main()
     "CUTEst_realloc",
     "CUTEst_free",
     "VarTypes",
+    "cutest_load_routines_",
+    "cutest_load_routines_s_",
+    "cutest_load_routines_q_",
+    "cutest_unload_routines_",
+    "cutest_unload_routines_s_",
+    "cutest_unload_routines_q_",
   ]
 
   args = get_default_args()

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -2276,6 +2276,30 @@ for (cutest_cish, T) in
 end
 
 """
+    cishp(T, libsif, status, n, iprob, nnzh, lh, irnh, icnh)
+"""
+function cishp end
+
+for (cutest_cishp, T) in
+    ((:cutest_cishp_s_, :Float32), (:cutest_cishp_, :Float64), (:cutest_cishp_q_, :Float128))
+  @eval begin
+    function cishp(
+      ::Type{$T},
+      libsif::Ptr{Cvoid},
+      status::StrideOneVector{Cint},
+      n::StrideOneVector{Cint},
+      iprob::StrideOneVector{Cint},
+      nnzh::StrideOneVector{Cint},
+      lh::StrideOneVector{Cint},
+      irnh::StrideOneVector{Cint},
+      icnh::StrideOneVector{Cint},
+    )
+      $cutest_cishp(libsif, status, n, iprob, nnzh, lh, irnh, icnh)
+    end
+  end
+end
+
+"""
     csgrsh(T, libsif, status, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh, h_val, h_row, h_col)
 
 The csgrsh subroutine evaluates the gradients of the general

--- a/src/libcutest.jl
+++ b/src/libcutest.jl
@@ -420,6 +420,12 @@ function cutest_cish_(libsif, status, n, x, iprob, nnzh, lh, h, irnh, icnh)
                            icnh::Ptr{Cint})::Cvoid
 end
 
+function cutest_cishp_(libsif, status, n, iprob, nnzh, lh, irnh, icnh)
+  ptr_cutest_cishp_ = Libdl.dlsym(libsif, :cutest_cishp_)
+  @ccall $ptr_cutest_cishp_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzh::Ptr{Cint},
+                            lh::Ptr{Cint}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
+end
+
 function cutest_cint_csgrsh_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar, indfun,
                              nnzh, lh, h, irnh, icnh)
   ptr_cutest_cint_csgrsh_ = Libdl.dlsym(libsif, :cutest_cint_csgrsh_)
@@ -974,6 +980,12 @@ function cutest_cish_s_(libsif, status, n, x, iprob, nnzh, lh, h, irnh, icnh)
   @ccall $ptr_cutest_cish_s_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float32}, iprob::Ptr{Cint},
                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float32}, irnh::Ptr{Cint},
                              icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cishp_s_(libsif, status, n, iprob, nnzh, lh, irnh, icnh)
+  ptr_cutest_cishp_s_ = Libdl.dlsym(libsif, :cutest_cishp_s_)
+  @ccall $ptr_cutest_cishp_s_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzh::Ptr{Cint},
+                              lh::Ptr{Cint}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_csgrsh_s_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar,
@@ -1534,6 +1546,12 @@ function cutest_cish_q_(libsif, status, n, x, iprob, nnzh, lh, h, irnh, icnh)
   @ccall $ptr_cutest_cish_q_(status::Ptr{Cint}, n::Ptr{Cint}, x::Ptr{Float128}, iprob::Ptr{Cint},
                              nnzh::Ptr{Cint}, lh::Ptr{Cint}, h::Ptr{Float128}, irnh::Ptr{Cint},
                              icnh::Ptr{Cint})::Cvoid
+end
+
+function cutest_cishp_q_(libsif, status, n, iprob, nnzh, lh, irnh, icnh)
+  ptr_cutest_cishp_q_ = Libdl.dlsym(libsif, :cutest_cishp_q_)
+  @ccall $ptr_cutest_cishp_q_(status::Ptr{Cint}, n::Ptr{Cint}, iprob::Ptr{Cint}, nnzh::Ptr{Cint},
+                              lh::Ptr{Cint}, irnh::Ptr{Cint}, icnh::Ptr{Cint})::Cvoid
 end
 
 function cutest_cint_csgrsh_q_(libsif, status, n, m, x, y, grlagf, nnzj, lcjac, cjac, indvar,


### PR DESCRIPTION
Require a new release of `CUTEst_jll.jl`.

References:
- https://github.com/ralna/CUTEst/commit/125f99fdde8aadd2f3b1d8524a2474388ddac6b4
- https://github.com/ralna/CUTEst/issues/110