### PR TITLE
Update compatibility for DataStructures 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CUTEst"
 uuid = "1b53aba6-35b6-5f92-a507-53c67d53f819"
-version = "1.3.6"
+version = "1.3.7"
 
 [deps]
 CUTEst_jll = "bb5f6f25-f23d-57fd-8f90-3ef7bad1d825"
@@ -19,7 +19,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 CUTEst_jll = "2.6.0"
 Combinatorics = "1.0"
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 JSON = "0.21"
 LazyArtifacts = "1.10"
 Libdl = "1.10"


### PR DESCRIPTION
Based on a quick look CUTEst.jl doesn't use things that changed in DataStructures.jl 0.19 but let's check CI.